### PR TITLE
Frontend plotting changes

### DIFF
--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -37,7 +37,9 @@
     "hint": "Hint:",
     "hint2": "Increasing your plots size will improve Farmer profitability.",
     "initial": "Initial plotting time:",
-    "suggest": "We suggest you retain at least 20 GB of free available space on this drive.",
+    "availableSpace": "How much free space there are in the disk.",
+    "utilizedSpace": "How much space is currently being used.",
+    "allocatedSpace": "Space to be shared with Subspace Protocol.",
     "plotsDirectory": "Plots Directory"
   },
   "plottingProgress": {
@@ -47,11 +49,9 @@
     "plotted": "Plotted",
     "elapsedTime": "Elapsed Time",
     "remainingTime": "Remaining Time",
-    "finish": "Finish",
     "hint": "Hint:",
     "resume": "Resume Plotting",
     "hintInfo": "Join the Subspace Discord while you wait, meet the community and earn some SSC",
-    "pause": "Pause Plotting",
     "remaining": "Remaining",
     "next": "Next"
   },

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -96,31 +96,13 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
     .col-expand
     .col-auto(v-if="viewedIntro")
       q-btn(
-        :label="lang.finish"
+        :label="lang.next"
         @click="$router.replace({ name: 'dashboard' })"
         color="blue-8"
         icon-right="play_arrow"
         outline
         size="lg"
-        v-if="plotFinished"
-      )
-      q-btn(
-        :label="lang.resume"
-        @click="startPlotting()"
-        color="blue-8"
-        icon-right="play_arrow"
-        outline
-        size="lg"
-        v-else-if="!plotting"
-      )
-      q-btn(
-        :label="lang.pause"
-        @click="pausePlotting()"
-        color="blue-8"
-        icon-right="pause"
-        outline
-        size="lg"
-        v-else
+        :disable="!plotFinished"
       )
     .col-auto(v-else)
       q-btn(

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -39,6 +39,8 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
                 suffix="GB"
                 v-model="stats.utilizedGB"
               )
+                q-tooltip.q-pa-sm
+                  p {{ lang.utilizedSpace }}
               .q-mt-sm {{ lang.available }}
               q-input(
                 :error="unsafeFree"
@@ -51,18 +53,19 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
                 v-model="stats.freeGB"
               )
                 q-tooltip.q-pa-sm
-                  p {{ lang.suggest }}
+                  p {{ lang.availableSpace }}
               .q-mt-sm {{ lang.allocated }}
-              q-input.q-field--highlighted(
+              q-input(
                 color="blue"
                 dense
                 input-class="pkdisplay"
                 outlined
+                readonly
                 suffix="GB"
-                type="number"
-                min="1"
                 v-model="allocatedGB"
               )
+                q-tooltip.q-pa-sm
+                  p {{ lang.allocatedSpace }}
         .col.q-pr-md
           .row.justify-center(style="transform: scale(-1, 1)")
             apexchart(
@@ -71,20 +74,6 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
               type="donut"
               width="200px"
             )
-          .row.q-mt-md
-            .col-1
-            .col
-              q-slider(
-                :max="stats.safeAvailableGB"
-                :min="0"
-                :step="1"
-                color="blue"
-                markers
-                snap
-                style="height: 25px"
-                v-model="allocatedGB"
-              )
-            .col-1
   .row.justify-end.q-mt-sm.absolute-bottom.q-pb-md
     .col-auto.q-pr-md
       div {{ lang.hint }}
@@ -162,7 +151,7 @@ export default defineComponent({
       revealKey: false,
       userConfirm: false,
       plotDirectory: "/Subspace/plots",
-      allocatedGB: 1,
+      allocatedGB: 10,
       validPath: true,
       defaultPath: "/",
       driveStats: <native.DriveStats>{ freeBytes: 0, totalBytes: 0 },


### PR DESCRIPTION
This PR is updating the frontend functionality for `plotting` process.

Changes are:
- `Allocated` space in the `SetupPlot` page is now read-only.
    - @1devNdogs , I think you can help with getting the value of total size from the blockchain Leo?
    - Right now, this value is set to a dummy value of 10 GB (we have to spend time in this step to demonstrate that the following functionalities work)
- Added new tooltips and updated the outdated ones for `utilized`, `available` and `allocated` spaces in the `SetupPlot` page.
- In the `PlottingProgress` page, `next` button is available while it is still plotting (so the user can view the tips, he doesn't need to wait for plotting to finish for that)
- `next` button is disabled if intro is viewed and plotting is not finished
- `next` button is available back again, and will proceed to the last page if intro has been viewed and plotting is finished.
- removed the `pause/resume` plotting buttons for now. I think this functionality will complicate the app. If we want it, we can always reintroduce them and connect them to the backend. At the moment, they were functionless buttons.

