### PR TITLE
Publish update

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,12 +2,9 @@ name: "ci tests"
 on:
   push:
     paths-ignore:
-      # ignore yaml files, since they need to be merged to main in order to take effect
-      - "**.yml"
       - "**.md"
   pull_request:
     paths-ignore:
-      - "**.yml"
       - "**.md"
 
 jobs:
@@ -66,13 +63,11 @@ jobs:
       - name: install app dependencies and build it
         run: npm install && npm build
         env:
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
 
       - name: tauri run
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
 
       - name: fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -61,7 +61,7 @@ jobs:
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
 
       - name: install app dependencies and build it
-        run: npm install && npm build
+        run: yarn install && yarn build
 
       - name: tauri run
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -64,7 +64,7 @@ jobs:
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
 
       - name: install app dependencies and build it
-        run: yarn && yarn build
+        run: npm install && npm build
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,9 +2,12 @@ name: "ci tests"
 on:
   push:
     paths-ignore:
+      # ignore yaml files, since they need to be merged to main in order to take effect
+      - "**.yml"
       - "**.md"
   pull_request:
     paths-ignore:
+      - "**.yml"
       - "**.md"
 
 jobs:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -62,7 +62,6 @@ jobs:
 
       - name: install app dependencies and build it
         run: npm install && npm build
-        env:
 
       - name: tauri run
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
 
       - name: install Rust nightly
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -61,7 +61,8 @@ jobs:
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
 
       - name: install app dependencies and build it
-        run: yarn install && yarn build
+        # sometimes it fails downloading packages, so set a timeout https://github.com/yarnpkg/yarn/issues/4890
+        run: yarn install --network-timeout 1000000 && yarn build
 
       - name: tauri run
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
 
       - name: install Rust nightly
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # Windows-2022 has been temporarily removed. We are unable to build 2x windows installs at the same name due to naming convention issues. Issue made upstream here: https://github.com/tauri-apps/tauri-action/issues/215
-        platform: [macos-latest, ubuntu-latest, windows-2019]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-2019
+          - windows-2022 # test again to see if it will fail, comment out this again if necessary
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
+      - name: git checkout
+        uses: actions/checkout@v2
+
       - name: setup node
         uses: actions/setup-node@v1
         with:
           node-version: 14
-      - name: install Rust stable
+
+      - name: install Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly-2021-12-14
+          override: true
+          components: rustfmt, clippy
+
+        # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
+      - name: Remove msys64
+        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
+        if: runner.os == 'Windows'
+
       - name: install webkit2gtk (ubuntu only)
         if: matrix.platform == 'ubuntu-latest'
         run: |
@@ -26,6 +41,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libappindicator3-dev0
 
       # Imports PFX Certificate into keystore, allows Tauri to then sign the exe without being passed the private key.
+      # This normally should not be required on CI-Tests, but due to the way that tauri has its code signing configuration for windows it is required that we sign or the build will fail.
       - name: import windows certificate
         if: runner.os == 'Windows'
         env:
@@ -37,10 +53,16 @@ jobs:
           certutil -decode certificate/tempCert.txt certificate/certificate.pfx
           Remove-Item –path certificate -include tempCert.txt
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
+
       - name: install app dependencies and build it
         run: yarn && yarn build
-      - uses: tauri-apps/tauri-action@v0
         env:
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
+
+      - name: tauri run
+        uses: tauri-apps/tauri-action@v0
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENABLE_CODE_SIGNING: ${{ secrets.MACOS_CERTIFICATE }}
           APPLE_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -53,4 +75,6 @@ jobs:
           releaseName: "App v__VERSION__"
           body: "See the assets to download this version and install."
           draft: true
-          prerelease: true
+          prerelease: false
+
+    # rust fmt and clippy actions are not included, since we should only release a version that is passed the tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-2019
-          - windows-2022 # test again to see if it will fail, comment out this again if necessary
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -25,7 +24,7 @@ jobs:
       - name: install Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-12-14
+          toolchain: nightly
           override: true
           components: rustfmt, clippy
 
@@ -41,7 +40,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libappindicator3-dev0
 
       # Imports PFX Certificate into keystore, allows Tauri to then sign the exe without being passed the private key.
-      # This normally should not be required on CI-Tests, but due to the way that tauri has its code signing configuration for windows it is required that we sign or the build will fail.
       - name: import windows certificate
         if: runner.os == 'Windows'
         env:
@@ -57,12 +55,10 @@ jobs:
       - name: install app dependencies and build it
         run: yarn && yarn build
         env:
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
 
       - name: tauri run
         uses: tauri-apps/tauri-action@v0
         env:
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENABLE_CODE_SIGNING: ${{ secrets.MACOS_CERTIFICATE }}
           APPLE_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -76,5 +72,3 @@ jobs:
           body: "See the assets to download this version and install."
           draft: true
           prerelease: false
-
-    # rust fmt and clippy actions are not included, since we should only release a version that is passed the tests


### PR DESCRIPTION
This updates the `publish.yml`. 
Right now, `publish.yml` is outdated, so we need to update it for releasing the desktop-app.

We also don't want regular CI jobs to trigger when `yml` files are edited. The reason is, yaml file changes only take effect when they are merged into main. So running the current tests when a `yml` file changes provides no extra information to us, just wastes time.

pre-release is set to true, I will change it back to `false` when we successfully integrate the node, and the desktop-app can be a standalone farming application.