### PR TITLE
Node integration without CLI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "names",
  "sc-chain-spec",
  "sc-executor",
+ "sc-network",
  "sc-service",
  "sc-tracing",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -109,22 +109,26 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenv",
- "dotenv_codegen",
  "event-listener-primitives",
+ "fdlimit",
  "fs2",
  "hex",
  "log",
- "sc-cli",
+ "names",
+ "sc-chain-spec",
  "sc-executor",
+ "sc-service",
+ "sc-tracing",
  "serde",
  "serde_json",
  "sp-core",
+ "sp-panic-handler",
  "subspace-core-primitives",
  "subspace-farmer",
- "subspace-node",
  "subspace-runtime",
  "subspace-service",
  "subspace-solving",
+ "substrate-build-script-utils",
  "tauri",
  "tauri-build",
  "tiny-bip39",
@@ -1742,7 +1746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
  "byteorder 1.4.3",
- "quick-error 1.2.3",
+ "quick-error",
 ]
 
 [[package]]
@@ -1750,29 +1754,6 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
-name = "dotenv_codegen"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56966279c10e4f8ee8c22123a15ed74e7c8150b658b26c619c53f4a56eb4a8aa"
-dependencies = [
- "dotenv_codegen_implementation",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "dotenv_codegen_implementation"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e737a3522cd45f6adc19b644ce43ef53e1e9045f2d2de425c1f468abd4cf33"
-dependencies = [
- "dotenv",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "downcast-rs"
@@ -2130,33 +2111,6 @@ dependencies = [
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
-]
-
-[[package]]
-name = "frame-benchmarking-cli"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=e6def65920d30029e42d498cb07cec5dd433b927#e6def65920d30029e42d498cb07cec5dd433b927"
-dependencies = [
- "Inflector",
- "chrono",
- "clap",
- "frame-benchmarking",
- "frame-support",
- "handlebars",
- "linked-hash-map",
- "log",
- "parity-scale-codec",
- "sc-cli",
- "sc-client-db",
- "sc-executor",
- "sc-service",
- "serde",
- "serde_json",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime",
- "sp-state-machine",
 ]
 
 [[package]]
@@ -2852,20 +2806,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "handlebars"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25546a65e5cf1f471f3438796fc634650b31d7fcde01d444c309aeb28b92e3a8"
-dependencies = [
- "log",
- "pest",
- "pest_derive",
- "quick-error 2.0.1",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4777,12 +4717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "markup5ever"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6160,40 +6094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest_derive"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
-dependencies = [
- "maplit",
- "pest",
- "sha-1 0.8.2",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6808,12 +6708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quicksink"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7162,7 +7056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
- "quick-error 1.2.3",
+ "quick-error",
 ]
 
 [[package]]
@@ -7217,16 +7111,6 @@ checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
-]
-
-[[package]]
-name = "rpassword"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -7466,44 +7350,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sc-cli"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=e6def65920d30029e42d498cb07cec5dd433b927#e6def65920d30029e42d498cb07cec5dd433b927"
-dependencies = [
- "chrono",
- "clap",
- "fdlimit",
- "futures 0.3.19",
- "hex",
- "libp2p 0.40.0",
- "log",
- "names",
- "parity-scale-codec",
- "rand 0.7.3",
- "regex",
- "rpassword",
- "sc-client-api",
- "sc-keystore",
- "sc-network",
- "sc-service",
- "sc-telemetry",
- "sc-tracing",
- "sc-utils",
- "serde",
- "serde_json",
- "sp-blockchain",
- "sp-core",
- "sp-keyring",
- "sp-keystore",
- "sp-panic-handler",
- "sp-runtime",
- "sp-version",
- "thiserror",
- "tiny-bip39",
- "tokio",
 ]
 
 [[package]]
@@ -9015,17 +8861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-keyring"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?rev=e6def65920d30029e42d498cb07cec5dd433b927#e6def65920d30029e42d498cb07cec5dd433b927"
-dependencies = [
- "lazy_static",
- "sp-core",
- "sp-runtime",
- "strum 0.23.0",
-]
-
-[[package]]
 name = "sp-keystore"
 version = "0.11.0"
 source = "git+https://github.com/paritytech/substrate?rev=e6def65920d30029e42d498cb07cec5dd433b927#e6def65920d30029e42d498cb07cec5dd433b927"
@@ -9589,28 +9424,6 @@ dependencies = [
  "subspace-core-primitives",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "subspace-node"
-version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=c76d6744a17933fe82811ad809856d665869cdaa#c76d6744a17933fe82811ad809856d665869cdaa"
-dependencies = [
- "clap",
- "frame-benchmarking-cli",
- "frame-support",
- "futures 0.3.19",
- "sc-cli",
- "sc-executor",
- "sc-service",
- "sc-telemetry",
- "sp-core",
- "sp-runtime",
- "subspace-runtime",
- "subspace-runtime-primitives",
- "subspace-service",
- "substrate-build-script-utils",
- "thiserror",
 ]
 
 [[package]]
@@ -10278,10 +10091,8 @@ dependencies = [
  "memchr",
  "mio 0.7.14",
  "num_cpus",
- "once_cell",
  "parking_lot 0.11.2",
  "pin-project-lite 0.2.8",
- "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.14"
 names = { version = "0.12.0", default-features = false }
 sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927", features = ["wasmtime"] }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 sc-tracing = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 serde_json = "1.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,8 +13,8 @@ substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/pa
 tauri-build = { version = "1.0.0-beta.4" }
 
 [dependencies]
-dotenv = "0.15.0"
 anyhow = "1.0.44"
+dotenv = "0.15.0"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.2.1"
 fs2 = "0.4.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,27 +7,30 @@ license = "Apache-2.0"
 repository = ""
 default-run = "app"
 edition = "2021"
-build = "src/build.rs"
 
 [build-dependencies]
+substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 tauri-build = { version = "1.0.0-beta.4" }
 
 [dependencies]
 dotenv = "0.15.0"
-dotenv_codegen = "0.15.0"
 anyhow = "1.0.44"
 event-listener-primitives = "2.0.1"
+fdlimit = "0.2.1"
 fs2 = "0.4.3"
 hex = "0.4.3"
 log = "0.4.14"
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927", features = ["wasmtime"] }
+names = { version = "0.12.0", default-features = false }
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927", features = ["wasmtime"] }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
+sc-tracing = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 serde_json = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 sp-core = { version = "5.0.0", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
+sp-panic-handler = { version = "4.0.0", git = "https://github.com/paritytech/substrate", rev = "e6def65920d30029e42d498cb07cec5dd433b927" }
 subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "c76d6744a17933fe82811ad809856d665869cdaa" }
 subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "c76d6744a17933fe82811ad809856d665869cdaa" }
-subspace-node = { git = "https://github.com/subspace/subspace", rev = "c76d6744a17933fe82811ad809856d665869cdaa" }
 subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "c76d6744a17933fe82811ad809856d665869cdaa" }
 subspace-service = { git = "https://github.com/subspace/subspace", rev = "c76d6744a17933fe82811ad809856d665869cdaa" }
 subspace-solving = { git = "https://github.com/subspace/subspace", rev = "c76d6744a17933fe82811ad809856d665869cdaa" }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 Subspace Labs, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
+
+fn main() {
+    tauri_build::build();
+
+    generate_cargo_keys();
+
+    rerun_if_git_head_changed();
+}

--- a/src-tauri/chain-spec-raw.json
+++ b/src-tauri/chain-spec-raw.json
@@ -5,12 +5,12 @@
     "Custom": "Subspace testnet"
   },
   "bootNodes": [
-    "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWJDsz9MQzHsBYwmbZnYQaVLEMAnmRpcADycdYxEX58GH4"
+    "/dns/farm-rpc.subspace.network/tcp/30333/p2p/12D3KooWPjMZuSYj35ehced2MTJFf95upwpHKgKUrFRfHwohzJXr"
   ],
   "telemetryEndpoints": [
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
-      0
+      1
     ]
   ],
   "protocolId": "subspace",

--- a/src-tauri/chain-spec.json
+++ b/src-tauri/chain-spec.json
@@ -5,12 +5,12 @@
     "Custom": "Subspace testnet"
   },
   "bootNodes": [
-    "/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWPyB1jvYdiy46ihAD1A854fsA5j1uVuYKrzRP7Tubt93t"
+    "/dns/farm-rpc.subspace.network/tcp/30333/p2p/12D3KooWPjMZuSYj35ehced2MTJFf95upwpHKgKUrFRfHwohzJXr"
   ],
   "telemetryEndpoints": [
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
-      0
+      1
     ]
   ],
   "protocolId": "subspace",

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+targets = ["wasm32-unknown-unknown"]
+profile = "default"

--- a/src-tauri/src/build.rs
+++ b/src-tauri/src/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    tauri_build::build()
-}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,7 @@ mod windows;
 
 mod node;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use bip39::{Language, Mnemonic};
 use log::{debug, error, info};
 use serde::Serialize;
@@ -170,7 +170,7 @@ async fn init_node(base_directory: PathBuf) -> Result<FarmerIdentity> {
         sc_service::GenericChainSpec::<subspace_runtime::GenesisConfig>::from_json_bytes(
             include_bytes!("../chain-spec.json").as_ref(),
         )
-        .map_err(|error| anyhow::Error::msg(error))?;
+        .map_err(anyhow::Error::msg)?;
 
     let mut full_client =
         Handle::current().block_on(node::create_full_client(chain_spec, base_directory))?;
@@ -266,13 +266,12 @@ async fn farm(base_directory: PathBuf, node_rpc_url: &str) -> Result<()> {
     tokio::spawn(async {
         tokio::select! {
             res = plotting_instance.wait() => if let Err(error) = res {
-                return Err(anyhow!(error)) // TODO: connect this error to frontend, or log it
+                error!("Plotting created the error: {error}");
             },
             res = farming_instance.wait() => if let Err(error) = res {
-                return Err(anyhow!(error)) // TODO: connect this error to frontend, or log it
+                error!("Farming created the error: {error}");
             },
         }
-        Ok(())
     });
 
     Ok(())

--- a/src-tauri/src/node.rs
+++ b/src-tauri/src/node.rs
@@ -10,8 +10,8 @@ use sc_service::config::{
     OffchainWorkerConfig,
 };
 use sc_service::{
-    BasePath, Configuration, DatabaseSource, KeepBlocks, Role, RpcMethods, TracingReceiver,
-    TransactionStorageMode,
+    BasePath, Configuration, DatabaseSource, KeepBlocks, PruningMode, Role, RpcMethods,
+    TracingReceiver, TransactionStorageMode,
 };
 use sc_tracing::logging::LoggerBuilder;
 use sp_core::crypto::Ss58AddressFormat;
@@ -155,7 +155,7 @@ fn create_configuration<CS: ChainSpec + 'static>(
         state_cache_size: 67_108_864,
         state_cache_child_ratio: None,
         // TODO: Change to constrained eventually (need DSN for this)
-        state_pruning: Default::default(),
+        state_pruning: PruningMode::ArchiveAll,
         keep_blocks: KeepBlocks::All,
         transaction_storage: TransactionStorageMode::BlockBody,
         wasm_method: WasmExecutionMethod::Compiled,

--- a/src-tauri/src/node.rs
+++ b/src-tauri/src/node.rs
@@ -1,0 +1,203 @@
+use anyhow::Result;
+use log::warn;
+use names::{Generator, Name};
+use sc_chain_spec::ChainSpec;
+use sc_executor::NativeExecutionDispatch;
+use sc_executor::WasmExecutionMethod;
+use sc_service::config::{KeystoreConfig, NetworkConfiguration, OffchainWorkerConfig};
+use sc_service::{
+    BasePath, Configuration, DatabaseSource, KeepBlocks, Role, RpcMethods, TracingReceiver,
+    TransactionStorageMode,
+};
+use sc_tracing::logging::LoggerBuilder;
+use sp_core::crypto::Ss58AddressFormat;
+use std::env;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Once;
+use subspace_service::{FullClient, NewFull};
+use tokio::runtime::Handle;
+
+static INITIALIZE_SUBSTRATE: Once = Once::new();
+
+/// The maximum number of characters for a node name.
+const NODE_NAME_MAX_LENGTH: usize = 64;
+
+/// Default sub directory to store network config.
+const DEFAULT_NETWORK_CONFIG_PATH: &'static str = "network";
+
+/// The recommended open file descriptor limit to be configured for the process.
+const RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT: u64 = 10_000;
+
+pub(crate) struct ExecutorDispatch;
+
+impl NativeExecutionDispatch for ExecutorDispatch {
+    type ExtendHostFunctions = ();
+
+    fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+        subspace_runtime::api::dispatch(method, data)
+    }
+
+    fn native_version() -> sc_executor::NativeVersion {
+        subspace_runtime::native_version()
+    }
+}
+
+// TODO: Allow customization of a bunch of these things
+pub(crate) async fn create_full_client<CS: ChainSpec + 'static>(
+    chain_spec: CS,
+    base_path: PathBuf,
+) -> Result<NewFull<Arc<FullClient<subspace_runtime::RuntimeApi, ExecutorDispatch>>>> {
+    // This must only be initialized once
+    INITIALIZE_SUBSTRATE.call_once(|| {
+        dotenv::dotenv().ok();
+
+        set_default_ss58_version(&chain_spec);
+
+        sp_panic_handler::set(
+            "https://discord.gg/vhKF9w3x",
+            env!("SUBSTRATE_CLI_IMPL_VERSION"),
+        );
+
+        LoggerBuilder::new("info")
+            .init()
+            .expect("Logger initialization must not fail");
+
+        if let Some(new_limit) = fdlimit::raise_fd_limit() {
+            if new_limit < RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT {
+                warn!(
+                    "Low open file descriptor limit configured for the process. \
+                    Current value: {:?}, recommended value: {:?}.",
+                    new_limit, RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT,
+                );
+            }
+        }
+    });
+
+    let config = create_configuration(
+        BasePath::Permanenent(base_path),
+        chain_spec,
+        Handle::current(),
+    )?;
+
+    subspace_service::new_full::<subspace_runtime::RuntimeApi, ExecutorDispatch>(config, true)
+        .await
+        .map_err(Into::into)
+}
+
+fn set_default_ss58_version<CS: ChainSpec>(chain_spec: &CS) {
+    let maybe_ss58_address_format = chain_spec
+        .properties()
+        .get("ss58Format")
+        .map(|v| {
+            v.as_u64()
+                .expect("ss58Format must always be an unsigned number; qed")
+        })
+        .map(|v| {
+            v.try_into()
+                .expect("ss58Format must always be within u16 range; qed")
+        })
+        .map(Ss58AddressFormat::custom);
+
+    if let Some(ss58_address_format) = maybe_ss58_address_format {
+        sp_core::crypto::set_default_ss58_version(ss58_address_format);
+    }
+}
+
+/// Create a Configuration object for the node
+fn create_configuration<CS: ChainSpec + 'static>(
+    base_path: BasePath,
+    chain_spec: CS,
+    tokio_handle: tokio::runtime::Handle,
+) -> Result<Configuration> {
+    let impl_name = "Subspace-desktop".to_string();
+    let impl_version = env!("SUBSTRATE_CLI_IMPL_VERSION").to_string();
+    let config_dir = base_path.config_dir(chain_spec.id());
+    let net_config_dir = config_dir.join(DEFAULT_NETWORK_CONFIG_PATH);
+    let client_id = format!("{}/v{}", impl_name, impl_version);
+    let database_cache_size = 1024;
+    let network = NetworkConfiguration::new(
+        generate_node_name(),
+        client_id,
+        Default::default(),
+        Some(net_config_dir),
+    );
+    let role = Role::Authority;
+    let (keystore_remote, keystore) = (None, KeystoreConfig::InMemory);
+    let telemetry_endpoints = chain_spec.telemetry_endpoints().clone();
+
+    // Default value are used for many of parameters
+    Ok(Configuration {
+        impl_name,
+        impl_version,
+        tokio_handle,
+        transaction_pool: Default::default(),
+        network,
+        keystore_remote,
+        keystore,
+        database: database_config(&config_dir, database_cache_size, &role),
+        state_cache_size: 67_108_864,
+        state_cache_child_ratio: None,
+        state_pruning: Default::default(),
+        keep_blocks: KeepBlocks::All,
+        transaction_storage: TransactionStorageMode::BlockBody,
+        wasm_method: WasmExecutionMethod::Compiled,
+        wasm_runtime_overrides: None,
+        execution_strategies: Default::default(),
+        rpc_http: None,
+        rpc_ws: Some("127.0.0.1:9945".parse().expect("IP and port are valid")),
+        rpc_ipc: None,
+        rpc_methods: RpcMethods::Auto,
+        rpc_ws_max_connections: None,
+        rpc_cors: Some(vec!["all".to_string()]),
+        rpc_max_payload: None,
+        ws_max_out_buffer_capacity: None,
+        prometheus_config: None,
+        telemetry_endpoints,
+        default_heap_pages: None,
+        offchain_worker: OffchainWorkerConfig::default(),
+        force_authoring: env::var("FORCE_AUTHORING")
+            .map(|force_authoring| force_authoring.as_str() == "1")
+            .unwrap_or_default(),
+        disable_grandpa: false,
+        dev_key_seed: None,
+        tracing_targets: None,
+        tracing_receiver: TracingReceiver::Log,
+        chain_spec: Box::new(chain_spec),
+        max_runtime_instances: 8,
+        announce_block: true,
+        role,
+        base_path: Some(base_path),
+        informant_output_format: Default::default(),
+        runtime_cache_size: 2,
+    })
+}
+
+/// Get the database configuration object for the parameters provided
+fn database_config(base_path: &PathBuf, cache_size: usize, role: &Role) -> DatabaseSource {
+    let role_dir = match role {
+        Role::Light => "light",
+        Role::Full | Role::Authority => "full",
+    };
+    let rocksdb_path = base_path.join("db").join(role_dir);
+    let paritydb_path = base_path.join("paritydb").join(role_dir);
+    DatabaseSource::Auto {
+        paritydb_path,
+        rocksdb_path,
+        cache_size,
+    }
+}
+
+/// Generate a valid random name for the node
+pub fn generate_node_name() -> String {
+    loop {
+        let node_name = Generator::with_naming(Name::Numbered)
+            .next()
+            .expect("RNG is available on all supported platforms; qed");
+        let count = node_name.chars().count();
+
+        if count < NODE_NAME_MAX_LENGTH {
+            return node_name;
+        }
+    }
+}

--- a/src-tauri/src/node.rs
+++ b/src-tauri/src/node.rs
@@ -12,7 +12,7 @@ use sc_service::{
 use sc_tracing::logging::LoggerBuilder;
 use sp_core::crypto::Ss58AddressFormat;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Once;
 use subspace_service::{FullClient, NewFull};
@@ -24,7 +24,7 @@ static INITIALIZE_SUBSTRATE: Once = Once::new();
 const NODE_NAME_MAX_LENGTH: usize = 64;
 
 /// Default sub directory to store network config.
-const DEFAULT_NETWORK_CONFIG_PATH: &'static str = "network";
+const DEFAULT_NETWORK_CONFIG_PATH: &str = "network";
 
 /// The recommended open file descriptor limit to be configured for the process.
 const RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT: u64 = 10_000;
@@ -174,7 +174,7 @@ fn create_configuration<CS: ChainSpec + 'static>(
 }
 
 /// Get the database configuration object for the parameters provided
-fn database_config(base_path: &PathBuf, cache_size: usize, role: &Role) -> DatabaseSource {
+fn database_config(base_path: &Path, cache_size: usize, role: &Role) -> DatabaseSource {
     let role_dir = match role {
         Role::Light => "light",
         Role::Full | Role::Authority => "full",

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -35,7 +35,7 @@
     "utilized": "Utilized",
     "allocated": "Allocated",
     "hint": "Hint:",
-    "hint2": "Increasing your plots size will improve Farmer profitability.",
+    "hint2": "Increasing your plots size will improve Farmer profitability (plot size will be configurable in the upcoming releases).",
     "initial": "Initial plotting time:",
     "availableSpace": "How much free space there are in the disk.",
     "utilizedSpace": "How much space is currently being used.",


### PR DESCRIPTION
This removes both `subspace-node` and `sc-cli` from dependencies since we want to run subspace node as a library, not as CLI application.

Have not tested this, but I think it should work. Chain spec might need to be modified to include correct bootstrap node, `FORCE_AUTHORING` environment variable can be used to force authoring. I also had to do a few minor tweaks.

Makes https://github.com/subspace/subspace/pull/274 unnecessary.