### PR TITLE
Switch CI to Windows 2022

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,7 +15,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-2019
           - windows-2022
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -64,7 +64,7 @@ jobs:
         run: yarn install --network-timeout 1000000 && yarn build
 
       - name: tauri run
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-2019
+          - windows-2022
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
         run: yarn install --network-timeout 1000000 && yarn build
 
       - name: tauri run
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENABLE_CODE_SIGNING: ${{ secrets.MACOS_CERTIFICATE }}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "subspace-desktop",
   "version": "0.1.0",
   "private": true,
-  "description": "Simple desktop app for Subspace farmers.",
-  "author": "Subspace Labs",
+  "description": "Subspace desktop",
+  "author": "Subspace Labs <https://subspace.network>",
   "license": "Apache-2.0",
   "scripts": {
     "lint": "yarn eslint --quiet ./src/",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -95,27 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
-name = "app"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "event-listener-primitives",
- "fs2",
- "lazy_static",
- "log",
- "serde",
- "serde_json",
- "subspace-core-primitives",
- "subspace-farmer",
- "subspace-solving",
- "tauri",
- "tauri-build",
- "tiny-bip39",
- "tokio",
- "winreg 0.10.1",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5419,6 +5398,27 @@ dependencies = [
  "serde",
  "serde_arrays",
  "sha2 0.10.1",
+]
+
+[[package]]
+name = "subspace-desktop"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "event-listener-primitives",
+ "fs2",
+ "lazy_static",
+ "log",
+ "serde",
+ "serde_json",
+ "subspace-core-primitives",
+ "subspace-farmer",
+ "subspace-solving",
+ "tauri",
+ "tauri-build",
+ "tiny-bip39",
+ "tokio",
+ "winreg 0.10.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
-name = "app"
+name = "subspace-desktop"
 version = "0.1.0"
-description = "A Tauri App"
-authors = [ "you" ]
+description = "Subspace desktop"
+authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"
-repository = ""
-default-run = "app"
+repository = "https://github.com/subspace/subspace-desktop"
 edition = "2021"
 build = "src/build.rs"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,4 @@
 {
-  "package": {
-    "productName": "Subspace Desktop",
-    "version": "0.1.0"
-  },
   "build": {
     "distDir": "../dist/pwa",
     "devPath": "http://localhost:8080",


### PR DESCRIPTION
Seems to work fine both on Windows 10 and WIndows 11, so we're switching monorepo to only build under Windows 2022, let's make the same here unless you are aware of any issues this may cause.