### PR TITLE
Frontend, fix info links, add testnet label

### DIFF
--- a/src/components/farmedList.vue
+++ b/src/components/farmedList.vue
@@ -10,7 +10,7 @@ q-card(bordered flat)
         h6 {{ farmedBlocksList?.length }}
       .col-auto.q-mr-md
         .text-weight-light Total Earned
-        p {{ farmedTotalEarned }} SSC
+        p {{ farmedTotalEarned }} tSSC
       q-space
       .col.col-auto
         .row.justify-center
@@ -55,7 +55,7 @@ q-card(bordered flat)
           .col-4
             p {{ new Date(block.time).toLocaleString() }}
           .col-2
-            p {{ block.blockReward }} SSC
+            p {{ block.blockReward }} tSSC
           .col-auto
             q-btn(color="grey" flat icon="info" size="sm")
 </template>

--- a/src/components/introModal.vue
+++ b/src/components/introModal.vue
@@ -31,11 +31,11 @@ mixin page3
       li
         p Did you know that subspace stores all data On-Chain!
       li
-        p You can talk with us on #[a(href="https://discord.gg/5MAp8CD684") Discord]
+        p You can talk with us on #[a(href="https://discord.gg/5MAp8CD684" target="_blank") Discord]
       li
-        p You can talk with us on #[a(href="https://t.me/subspacelabs") Telegram]
+        p You can talk with us on #[a(href="https://t.me/subspacelabs" target="_blank") Telegram]
       li
-        p Visit us on #[a(href="https://twitter.com/NetworkSubspace") Twitter]
+        p Visit us on #[a(href="https://twitter.com/NetworkSubspace" target="_blank") Twitter]
       li
         p Read up about subspace on #[a(href="https://medium.com/subspace-network" target="_blank") Medium]
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -4,27 +4,35 @@ q-layout(view="hHh lpr fFf")
     q-toolbar
       q-img(no-spinner src="subspacelogo.png" width="150px")
       q-toolbar-title
-        // Show the dashboard status indicator when on the dashboard page.
-        .row(v-if="$route.name == 'dashboard'")
+        .row
           .col-auto.q-mr-md.relative-position
+            q-badge(color="grey" text-color="white")
+              .q-pa-xs(style="font-size: 14px") {{ lang.nonIncentivizedLabel }}
+            q-tooltip
+              .col
+                p.no-margin(style="font-size: 12px") {{ lang.nonIncentivizedTooltip }}
+          // Show the dashboard status indicator when on the dashboard page. 
+          .col-auto.q-mr-md.relative-position(
+            v-if="$route.name == 'dashboard'"
+          )
             q-icon(
               color="green-5"
               name="trip_origin"
-              size="40px"
+              size="28px"
               style="bottom: 0px; right: 5px"
               v-if="global.status.state == 'live'"
             )
             q-icon(
               color="yellow-8"
               name="trip_origin"
-              size="40px"
+              size="28px"
               style="bottom: 0px; right: 5px"
               v-if="global.status.state == 'loading'"
             )
             q-tooltip
               .col
                 p Farmer Status:
-                h6.no-margin {{ global.status.message }}
+                p <b>{{ global.status.message }}</b>
       div
         q-btn(flat icon="settings" round)
           MainMenu
@@ -38,6 +46,7 @@ import { defineComponent } from "vue"
 import { globalState as global } from "src/lib/global"
 import * as util from "src/lib/util"
 import MainMenu from "components/mainMenu.vue"
+const lang = global.data.loc.text.mainMenu
 
 export default defineComponent({
   name: "MainLayout",
@@ -46,6 +55,7 @@ export default defineComponent({
 
   data() {
     return {
+      lang,
       global: global.data,
       util,
       autoLaunch: false

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -55,7 +55,7 @@
     "remainingTime": "Remaining Time",
     "hint": "Hint:",
     "resume": "Resume Plotting",
-    "hintInfo": "Join the Subspace Discord while you wait, meet the community and earn some SSC",
+    "hintInfo": "Join the Subspace Discord while you wait, meet the community and earn some tSSC",
     "remaining": "Remaining",
     "next": "Next"
   },

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -97,6 +97,8 @@
     "back": "back"
   },
   "mainMenu": {
+    "nonIncentivizedLabel": "Non-Incentivized Testnet",
+    "nonIncentivizedTooltip": "Farming and rewards have no real financial benefit at this time.",
     "reset": "Reset",
     "autoStart": "Start on Boot",
     "willAutoLaunch": "Subspace will launch automatically during boot",

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -149,7 +149,7 @@ export default defineComponent({
         progress: true,
         message: `${lang.farmedBlock}: ${block.blockNum} ${lang.reward} ${
           block.blockReward + block.feeReward
-        } SSC`,
+        } tSSC`,
         position: "bottom-right"
       })
     }


### PR DESCRIPTION
# Summary

- Fix #83 
  - Added missing target to info links 
  
- Fix #92 
  - @ImmaZoni we can use only a label with no tooltip.
![image](https://user-images.githubusercontent.com/11360704/158315297-69ce6929-62fc-402b-97e5-0d49301482dc.png)

  - Or we can use a grey label + tooltip. If so, please update the [lang](https://github.com/subspace/subspace-desktop/blob/eea7c09064051ab42b5f825bdde4ec313d60e227/src/loc/en.json#L101) file with a better description if necesary  
 ![image](https://user-images.githubusercontent.com/11360704/158308205-9f4ca594-98ce-42fb-b79a-2f7ee33d30ff.png)


