### PR TITLE
Macos sign fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,4 +70,4 @@ jobs:
           releaseName: "__VERSION__"
           body: "See the assets to download this version and install."
           draft: true
-          prerelease: true
+          prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,4 +70,4 @@ jobs:
           releaseName: "__VERSION__"
           body: "See the assets to download this version and install."
           draft: true
-          prerelease: false
+          prerelease: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Subspace desktop",
   "author": "Subspace Labs <https://subspace.network>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9341,7 +9341,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "dotenv",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-desktop"
-version = "0.2.0"
+version = "1"
 description = "Subspace desktop"
 authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-desktop"
-version = "1"
+version = "0.2.1"
 description = "Subspace desktop"
 authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.developer.kernel.increased-memory-limit</key>
-    <true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
 </dict>


### PR DESCRIPTION
macos signing now works (also thanks to @ImmaZoni for his suggestion).
Fixes #93 

Not important: publish.yml was creating some warnings due to `body` and `draft` are not recognized in the `tauri run` job.
They should be `releaseBody` and `releaseDraft`. Check the link below for confirmation on this:
https://github.com/tauri-apps/tauri-action