### PR TITLE
autoLaunch fix and version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-desktop",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "description": "Subspace desktop",
   "author": "Subspace Labs <https://subspace.network>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9494,7 +9494,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-desktop"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dotenv",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-desktop"
-version = "0.2.2"
+version = "0.3.0"
 description = "Subspace desktop"
 authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -7,10 +7,10 @@ q-menu(auto-close)
           q-toggle(
             :disable="disableAutoLaunch"
             @click="toggleClicked()"
-            v-model="autoLaunch"
+            v-model="launchOnStart"
           )
         .col
-          p.text-grey(v-if="!autoLaunch") {{ lang.autoStart }}
+          p.text-grey(v-if="!launchOnStart") {{ lang.autoStart }}
           p.text-black(v-else) {{ lang.autoStart }}
     q-item(@click="reset()" clickable)
       .row.items-center
@@ -32,8 +32,8 @@ export default defineComponent({
   data() {
     return {
       lang,
-      autoLaunch: false,
-      launchOnBoot: global.autoLauncher,
+      launchOnStart: false,
+      autoLauncher: global.autoLauncher,
       disableAutoLaunch: false
     }
   },
@@ -49,8 +49,8 @@ export default defineComponent({
         })
         return
       }
-      console.log("toggle Clicked", this.autoLaunch)
-      if (this.autoLaunch)
+      console.log("toggle Clicked", this.launchOnStart)
+      if (this.launchOnStart)
         Notify.create({
           message: lang.willAutoLaunch,
           icon: "info",
@@ -64,10 +64,10 @@ export default defineComponent({
           group: 1,
           badgeStyle: "visibility:hidden;"
         })
-      if (this.autoLaunch) {
-        await this.launchOnBoot.enable()
+      if (this.launchOnStart) {
+        await this.autoLauncher.enable()
       } else {
-        await this.launchOnBoot.disable()
+        await this.autoLauncher.disable()
       }
     },
     reset() {
@@ -93,12 +93,11 @@ export default defineComponent({
       })
     },
     async initMenu() {
-      console.log("Init Menu", typeof this.launchOnBoot.enabled)
-
-      if (this.launchOnBoot.enabled != undefined)
-        this.autoLaunch = this.launchOnBoot.enabled
+      if (this.autoLauncher.enabled != undefined) {
+        this.launchOnStart = await this.autoLauncher.enabled
+      }
       else {
-        this.autoLaunch = false
+        this.launchOnStart = false
         this.disableAutoLaunch = true
       }
     }

--- a/src/lib/appConfig.ts
+++ b/src/lib/appConfig.ts
@@ -22,7 +22,7 @@ export const appConfig = {
       if (plot) newAppConfig.plot = plot
       if (account) newAppConfig.account = account
       if (segmentCache) newAppConfig.segmentCache = segmentCache
-      if (launchOnBoot) newAppConfig.launchOnBoot = launchOnBoot
+      if (launchOnBoot != null) newAppConfig.launchOnBoot = launchOnBoot
       LocalStorage.set("appConfig", newAppConfig)
     }
   }


### PR DESCRIPTION
AutoLaunch bug (not remembering the config) was fixed before. But after local storage changes, it regressed and reappeared. 

The fix was pretty simple (inspect appConfig.ts file). Now it should be fine, and more safe (there are few improvements on `enable` and `disable` functions.

Other than that, the naming was confusing and not making sense for `autoLaunch` related variables in `mainMenu`. 

Lastly, bumped the version to 0.3.0 after massive changes we had recently, and will publish a pre-release after this PR