### PR TITLE
notify for autolaunch

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -25,7 +25,7 @@ import { defineComponent } from "vue"
 import { globalState as global } from "src/lib/global"
 import * as util from "src/lib/util"
 import { appConfig } from "src/lib/appConfig"
-import { LocalStorage } from "quasar"
+import { Notify } from "quasar"
 const lang = global.data.loc.text.index
 
 export default defineComponent({
@@ -66,6 +66,13 @@ export default defineComponent({
     firstLoad() {
       console.log("INDEX - First Time RUN.")
       this.loadNetworkData()
+      const config = appConfig.getAppConfig()
+      if (config && config.launchOnBoot == true) {
+        Notify.create({
+          message: "Subspace Desktop will be started on boot. You can disable this from settings (the gear icon on top-right).",
+          icon: "info"
+        })
+      }
     },
     async loadNetworkData() {
       await this.client.connectPublicApi()


### PR DESCRIPTION
Waiting for #139 to merge (for remembering the LaunchOnBoot preference bug fix)

Fixes #136 .

Did not want to complicate the application by prompting the user for permission on this. Instead, we are notifying the user about the app will be launched on boot, and if wanted, it can be disabled from settings.