### PR TITLE
reward address is displayed

### DIFF
--- a/src/components/farmedList.vue
+++ b/src/components/farmedList.vue
@@ -6,11 +6,14 @@ q-card(bordered flat)
         .row.items-center
           q-icon.q-mr-sm(color="grey" name="grid_view" size="40px")
           .text-h6.text-weight-light {{ lang.farmedBlocks }}:
-      .col-auto.q-mr-md
+      .col-auto.q-mr-xl
         h6 {{ farmedBlocksList?.length }}
-      .col-auto.q-mr-md
+      .col-auto.q-mr-xl
         .text-weight-light Total Earned
         p {{ farmedTotalEarned }} testnetSSC
+      .col-auto
+        .text-weight-light Reward Address
+        .reward-address {{ rewardAddress }}
       q-space
       .col.col-auto
         .row.justify-center
@@ -64,6 +67,8 @@ import * as util from "src/lib/util"
 import { globalState as global } from "src/lib/global"
 import { FarmedBlock } from "src/lib/types"
 import { formatDistanceToNowStrict } from "date-fns"
+import { LocalStorage } from "quasar"
+import { appConfig } from "src/lib/appConfig"
 
 const lang = global.data.loc.text.dashboard
 
@@ -74,7 +79,10 @@ export default defineComponent({
   },
   emits: ["expand"],
   data() {
-    return { lang, util, global: global.data, client: global.client }
+    return { lang, util, global: global.data, client: global.client, rewardAddress: "", }
+  },
+  mounted() {
+    this.displayRewardAddress()
   },
   computed: {
     farmedBlocksList(): FarmedBlock[] {
@@ -87,7 +95,28 @@ export default defineComponent({
   methods: {
     formatDate(date: Date) {
       return formatDistanceToNowStrict(date)
+    },
+    displayRewardAddress() {
+      const addr: string | null = LocalStorage.getItem("rewardAddress")
+      if (addr == null) {
+        const config = appConfig.getAppConfig()
+        if (config) {
+          const { farmerPublicKey } = config.account
+          const addr2: string = addr ?? farmerPublicKey
+          return this.rewardAddress = addr2
+        }
+      return this.rewardAddress = ""
+      } else {
+        return this.rewardAddress = addr
+      }
     }
   }
 })
 </script>
+
+<style lang="sass">
+.reward-address
+  padding-top: 5px
+  padding-bottom: 6px
+  font-size: 10px
+</style>


### PR DESCRIPTION
Trivial PR for frontend.
Displays the reward address in the dashboard statically (even when there are 0 block farmed)

Fixes #157 
<img width="802" alt="Screen Shot 2022-04-11 at 13 58 25" src="https://user-images.githubusercontent.com/32795992/162726462-a66c6ed7-2448-439a-99a1-423697fc7a60.png">

