### PR TITLE
mnemonic workflow fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@polkadot/api": "^7.2.1",
+    "@polkadot/util-crypto": "^9.0.1",
     "@quasar/extras": "^1.0.0",
     "@tauri-apps/api": "^1.0.0-rc.2",
     "@tsmx/human-readable": "^1.0.6",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9526,7 +9526,6 @@ dependencies = [
  "substrate-build-script-utils",
  "tauri",
  "tauri-build",
- "tiny-bip39",
  "tokio",
  "winreg 0.10.1",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,6 @@ subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "46420f7
 subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "46420f74bc87f38795a7a4a0196d7214f90ed929" }
 subspace-service = { git = "https://github.com/subspace/subspace", rev = "46420f74bc87f38795a7a4a0196d7214f90ed929" }
 subspace-solving = { git = "https://github.com/subspace/subspace", rev = "46420f74bc87f38795a7a4a0196d7214f90ed929" }
-tiny-bip39 = "0.8.2"
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,6 @@ mod menu;
 mod node;
 
 use anyhow::Result;
-use bip39::{Language, Mnemonic};
 use log::{debug, error, info};
 use serde::Serialize;
 use std::path::PathBuf;
@@ -69,11 +68,6 @@ async fn start_node(path: String) -> [u8; 32] {
 }
 
 #[tauri::command]
-fn identity_create(path: String) -> String {
-    create_identity(path.into()).unwrap()
-}
-
-#[tauri::command]
 fn get_disk_stats(dir: String) -> DiskStats {
     debug!("{}", dir);
     let free: u64 = fs2::available_space(&dir).expect("error");
@@ -129,8 +123,7 @@ async fn main() -> Result<()> {
                 get_this_binary,
                 farming,
                 plot_progress_tracker,
-                start_node,
-                identity_create
+                start_node
             ],
             #[cfg(target_os = "windows")]
             tauri::generate_handler![
@@ -141,8 +134,7 @@ async fn main() -> Result<()> {
                 get_disk_stats,
                 farming,
                 plot_progress_tracker,
-                start_node,
-                identity_create
+                start_node
             ],
         )
         .build(tauri::generate_context!())
@@ -197,16 +189,6 @@ async fn init_node(base_directory: PathBuf) -> Result<[u8; 32]> {
     });
 
     Ok(public_key)
-}
-
-fn create_identity(base_directory: PathBuf) -> Result<String> {
-    let identity = Identity::open_or_create(&base_directory)?;
-
-    Ok(
-        Mnemonic::from_entropy(identity.entropy(), Language::English)
-            .unwrap()
-            .into_phrase(),
-    )
 }
 
 /// Start farming by using plot in specified path and connecting to WebSocket server at specified

--- a/src/components/SaveKeys.vue
+++ b/src/components/SaveKeys.vue
@@ -13,7 +13,7 @@
                 input-class="mnemonic"
                 outlined
                 readonly
-                ref="pkDisplay"
+                ref="mnemonicDisplay"
                 style="width: 800px; height: 100px"
                 type="textarea"
                 v-model="mnemonic"
@@ -29,7 +29,7 @@
           .row.justify-center.q-mt-md(v-if="revealKey")
             q-btn(
               :label="lang.copy"
-              @click="copyPk"
+              @click="copyMnemonic"
               color="primary"
               style="max-width: 200px"
             )
@@ -65,13 +65,13 @@ export default defineComponent({
     global.client.clearMnemonic()
   },
   methods: {
-    copyPk() {
-      const displaypk = this.$refs["pkDisplay"] as QInput
+    copyMnemonic() {
+      const displayMnemonic = this.$refs["mnemonicDisplay"] as QInput
       const previousState = this.revealKey
       this.revealKey = true
       this.$nextTick(() => {
-        displaypk.focus()
-        displaypk.select()
+        displayMnemonic.focus()
+        displayMnemonic.select()
         var successful = document.execCommand("copy")
         var msg = successful ? "successful" : "unsuccessful"
         console.log(msg)

--- a/src/components/introModal.vue
+++ b/src/components/introModal.vue
@@ -11,13 +11,6 @@ mixin page1
     br
     p If your "fruit is ripe" aka if you have a plot that wins the current challenge then you are rewarded with subspace credits. aka "Winning the block".
 mixin page2
-  .row.justify-center.q-mb-md
-    .col-auto
-    //- q-icon(color="blue-3" name="vpn_key" size="80px")
-    .col
-      .row.q-mb-md
-        saveKeys(@userConfirm="userConfirm")
-mixin page3
   .row.justify-center.q-pb-md.items-center
     .col-auto.q-mr-md
       q-icon(color="yellow" name="lightbulb" size="100px")
@@ -51,8 +44,6 @@ q-dialog(@hide="onDialogHide" persistent ref="dialog")
           +page1
         div(v-if="currentPage == 2")
           +page2
-        div(v-if="currentPage == 3")
-          +page3
         .absolute-bottom.q-pa-md
           .row.justify-center.absolute-bottom
             q-icon.q-mr-xs(
@@ -63,36 +54,17 @@ q-dialog(@hide="onDialogHide" persistent ref="dialog")
             )
           .row.justify-end
             q-btn(
-              @click="proceedToMnemonic"
-              label="next"
-              outline
-              size="lg"
-              stretch
-              v-if="currentPage == 1"
-            )
-            q-btn(
-              :disabled="!userConfirmed"
               @click="currentPage++"
               label="next"
               outline
               size="lg"
               stretch
-              v-if="currentPage == 2"
-            )
-            q-btn(
-              @click="currentPage++"
-              label="next"
-              outline
-              size="lg"
-              stretch
-              v-if="currentPage == 3"
             )
 </template>
 
 <script>
 import { defineComponent } from "vue"
 import saveKeys from "components/SaveKeys.vue"
-import { appConfig } from "src/lib/appConfig"
 const component = defineComponent({
   components: { saveKeys },
   props: {
@@ -106,9 +78,8 @@ const component = defineComponent({
   ],
   data() {
     return {
-      totalPages: 3,
+      totalPages: 2,
       currentPage: 1,
-      userConfirmed: false
     }
   },
   watch: {
@@ -117,17 +88,6 @@ const component = defineComponent({
     }
   },
   methods: {
-    proceedToMnemonic() {
-      const config = appConfig.getAppConfig()
-      if (config && config.importedRewAddr) {
-        this.currentPage += 2
-      } else {
-        this.currentPage += 1
-      }
-    },
-    userConfirm(val) {
-      this.userConfirmed = val
-    },
     // following method is REQUIRED
     // (don't change its name --> "show")
     show() {

--- a/src/components/mnemonicModal.vue
+++ b/src/components/mnemonicModal.vue
@@ -1,0 +1,106 @@
+<template lang="pug">
+mixin page1
+  .row.justify-center.q-mb-md
+    .col-auto
+    //- q-icon(color="blue-3" name="vpn_key" size="80px")
+    .col
+      .row.q-mb-md
+        saveKeys(@userConfirm="userConfirm")
+
+q-dialog(@hide="onDialogHide" persistent ref="dialog")
+  q-card.q-dialog-plugin.relative-position(
+    bordered
+    flat
+    style="width: 600px; height: 500px"
+  )
+    div
+      .q-ma-md
+        div(v-if="currentPage == 1")
+          +page1
+        .absolute-bottom.q-pa-md
+          .row.justify-center.absolute-bottom
+            q-icon.q-mr-xs(
+              :name="currentPage == page ? 'radio_button_checked' : 'radio_button_unchecked'"
+              size="20px"
+              style="margin-bottom: 32px"
+              v-for="page of totalPages"
+            )
+          .row.justify-end
+            q-btn(
+              :disabled="!userConfirmed"
+              @click="currentPage++"
+              label="next"
+              outline
+              size="lg"
+              stretch
+              v-if="currentPage == 1"
+            )
+</template>
+
+<script>
+import { defineComponent } from "vue"
+import saveKeys from "components/SaveKeys.vue"
+const component = defineComponent({
+  components: { saveKeys },
+  props: {
+    // ...your custom props
+  },
+
+  emits: [
+    // REQUIRED
+    "ok",
+    "hide"
+  ],
+  data() {
+    return {
+      totalPages: 1,
+      currentPage: 1,
+      userConfirmed: false
+    }
+  },
+  watch: {
+    currentPage(val) {
+      if (val > this.totalPages) this.hide()
+    }
+  },
+  methods: {
+    userConfirm(val) {
+      this.userConfirmed = val
+    },
+    // following method is REQUIRED
+    // (don't change its name --> "show")
+    show() {
+      this.$refs.dialog.show()
+    },
+
+    // following method is REQUIRED
+    // (don't change its name --> "hide")
+    hide() {
+      this.$refs.dialog.hide()
+    },
+
+    onDialogHide() {
+      // required to be emitted
+      // when QDialog emits "hide" event
+      this.$emit("hide")
+    },
+
+    onOKClick() {
+      // on OK, it is REQUIRED to
+      // emit "ok" event (with optional payload)
+      // before hiding the QDialog
+      this.$emit("ok")
+      // or with payload: this.$emit('ok', { ... })
+
+      // then hiding dialog
+      this.hide()
+    },
+
+    onCancelClick() {
+      // we just need to hide the dialog
+      this.hide()
+    }
+  }
+})
+export default component
+</script>

--- a/src/lib/appConfig.ts
+++ b/src/lib/appConfig.ts
@@ -15,7 +15,8 @@ export const appConfig = {
     account: Account | null,
     segmentCache: SegmentCache | null,
     launchOnBoot: boolean | null,
-    importedRewAddr: boolean | null
+    importedRewAddr: boolean | null,
+    plottingStarted: boolean | null
   ): void {
     const appConfig = this.getAppConfig()
     if (appConfig) {
@@ -25,6 +26,7 @@ export const appConfig = {
       if (segmentCache) newAppConfig.segmentCache = segmentCache
       if (launchOnBoot != null) newAppConfig.launchOnBoot = launchOnBoot
       if (importedRewAddr != null) newAppConfig.importedRewAddr = importedRewAddr
+      if (plottingStarted != null) newAppConfig.plottingStarted = plottingStarted
       LocalStorage.set("appConfig", newAppConfig)
     }
   }

--- a/src/lib/appData.ts
+++ b/src/lib/appData.ts
@@ -36,7 +36,7 @@ export const appDataDialog = {
   },
   newDirectoryConfirm(
     plotDirectory: string,
-    startPlotting: () => Promise<void>
+    prepareForPlotting: () => Promise<void>
   ): void {
     Dialog.create({
       title: `Do you want to create a new directory?`,
@@ -53,12 +53,12 @@ export const appDataDialog = {
       ok: { label: "Create", icon: "check", flat: true, color: "blue" },
       cancel: { label: "Cancel", icon: "cancel", flat: true, color: "grey" }
     }).onOk(() => {
-      startPlotting()
+      prepareForPlotting()
     })
   },
   existingDirectoryConfirm(
     plotDirectory: string,
-    startPlotting: () => Promise<void>
+    prepareForPlotting: () => Promise<void>
   ): void {
     Dialog.create({
       title: `Confirm selected directory.`,
@@ -85,7 +85,7 @@ export const appDataDialog = {
         color: "grey"
       }
     }).onOk(() => {
-      startPlotting()
+      prepareForPlotting()
     })
   }
 }

--- a/src/lib/autoLauncher.ts
+++ b/src/lib/autoLauncher.ts
@@ -139,14 +139,14 @@ export class AutoLauncher {
     const child = await this.autoLauncher.enable({ appName: this.appName, appPath: this.appPath, minimized: true })
     this.enabled = await this.isEnabled()
     if (this.enabled == false) console.log("ENABLE DID NOT WORK")
-    else appConfig.updateAppConfig(null, null, null, true, null)
+    else appConfig.updateAppConfig(null, null, null, true, null, null)
     return child
   }
   async disable(): Promise<void | ChildReturnData> {
     const child = this.autoLauncher.disable(this.appName)
     this.enabled = await this.isEnabled()
     if (this.enabled == true) console.log("DISABLE DID NOT WORK")
-    else appConfig.updateAppConfig(null, null, null, false, null)
+    else appConfig.updateAppConfig(null, null, null, false, null, null)
     return child
   }
   async init(): Promise<void> {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -45,6 +45,7 @@ export interface AppConfig {
   segmentCache: SegmentCache
   launchOnBoot: boolean
   importedRewAddr: boolean
+  plottingStarted: boolean
 }
 
 export interface SegmentCache {
@@ -64,7 +65,8 @@ export const emptyAppConfig: AppConfig = {
   account: { farmerPublicKey: "" },
   segmentCache: { networkSegmentCount: 0, blockchainSizeGB: 0 },
   launchOnBoot: true,
-  importedRewAddr: false
+  importedRewAddr: false,
+  plottingStarted: false
 }
 
 export function formatMS(duration: number): string {

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -43,6 +43,7 @@
     "elapsedTime": "Elapsed Time",
     "remainingTime": "Remaining Time",
     "hint": "Hint:",
+    "hints": "Hints",
     "resume": "Resume Plotting",
     "hintInfo": "Join the Subspace Discord while you wait, meet the community and earn some testnetSSC",
     "remaining": "Remaining",

--- a/src/pages/ImportKey.vue
+++ b/src/pages/ImportKey.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     },
     async importKey() {
       LocalStorage.set("rewardAddress", this.rewardAddress)
-      appConfig.updateAppConfig(null, null, null, null, true)
+      appConfig.updateAppConfig(null, null, null, null, true, null)
       this.$router.replace({ name: "setupPlot" })
     },
     skip() {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -37,11 +37,9 @@ export default defineComponent({
       this.checkDev()
       const config = appConfig.getAppConfig()
       if (config) {
-        const { plot, account } = config
+        const { plottingStarted } = config
         if (
-          plot &&
-          account &&
-          plot.location.length > 0
+          plottingStarted
         ) {
           console.log("INDEX - NOT First Time RUN.")
           this.dashboard()
@@ -82,7 +80,7 @@ export default defineComponent({
       appConfig.updateAppConfig(null, null, {
         networkSegmentCount,
         blockchainSizeGB: blockchainSizeGB === 0 ? 0.1 : blockchainSizeGB
-      }, null, null)
+      }, null, null, null)
     }
   }
 })

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -95,7 +95,16 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
       div {{ lang.hintInfo }}
     .col-auto.q-pr-md
     .col-expand
-    .col-auto(v-if="viewedIntro")
+    .col-auto
+      q-btn(
+        :label="lang.hints"
+        @click="viewIntro()"
+        color="blue-8"
+        icon-right="info"
+        outline
+        size="lg"
+      )
+    .col-auto
       q-btn(
         :label="lang.next"
         @click="$router.replace({ name: 'dashboard' })"
@@ -107,15 +116,6 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
       )
       q-tooltip.q-pa-md(v-if="!plotFinished")
         p.q-mb-lg {{ lang.waitPlotting }}
-    .col-auto(v-else)
-      q-btn(
-        :label="lang.next"
-        @click="viewIntro()"
-        color="blue-8"
-        icon-right="play_arrow"
-        outline
-        size="lg"
-      )
 </template>
 
 <script lang="ts">

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -220,7 +220,7 @@ export default defineComponent({
             {
               farmerPublicKey: publicKey.toString()
             },
-            null, null, null
+            null, null, null, null
           )
         }
       } else {
@@ -232,8 +232,6 @@ export default defineComponent({
       clearInterval(farmerTimer)
     },
     async farmingWrapper(): Promise<void> {
-
-
       const config = appConfig.getAppConfig()
       if (config) {
         await this.client.startBlockSubscription()
@@ -247,6 +245,7 @@ export default defineComponent({
           this.localSegmentCount = await this.client.getLocalSegmentCount()
         } while (this.localSegmentCount < this.networkSegmentCount)
       }
+      appConfig.updateAppConfig(null, null, null, null, null, true)
     },
     startTimers() {
       farmerTimer = window.setInterval(() => {

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -152,7 +152,6 @@ export default defineComponent({
   data() {
     return {
       revealKey: false,
-      userConfirm: false,
       plotDirectory: "/",
       allocatedGB: 1,
       blockchainSizeGB: 0,

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -298,7 +298,7 @@ export default defineComponent({
     async checkIdentity() {
       const config = appConfig.getAppConfig()
       if (config && config.importedRewAddr === false) {
-        await this.client.createIdentity(this.plotDirectory)
+        await this.client.createRewardAddress()
         await this.viewMnemonic()
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.17.9":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -1007,10 +1014,20 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-0.5.7.tgz#8605d84b34daf43d15c344fae54f0a1d5d5a4632"
   integrity sha512-R9PPYv7TqoYi+enikzZvwRQesGTxR0+jwqzZJGL0uNcf2NFL+lt/uvCCewtXXmr6jWBxiMuNjBfJwKv9UJaCng==
 
+"@noble/hashes@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.0.0.tgz#d5e38bfbdaba174805a4e649f13be9a9ed3351ae"
+  integrity sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg==
+
 "@noble/secp256k1@1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.3.4.tgz#158ded712d09237c0d3428be60dc01ce8ebab9fb"
   integrity sha512-ZVRouDO5mbdCiDg4zCd3ZZABduRtpy4tCnB33Gh9upHe9tRzpiqbRSN1VTjrj/2g8u2c6MBi0YLNnNQpBYOiWg==
+
+"@noble/secp256k1@1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.5.5.tgz#315ab5745509d1a8c8e90d0bdf59823ccf9bcfc3"
+  integrity sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1117,6 +1134,15 @@
   dependencies:
     "@babel/runtime" "^7.16.7"
     "@polkadot/util" "8.3.1"
+
+"@polkadot/networks@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-9.0.1.tgz#6bb6af0a98f3c35f76427e533dfd5359387e7016"
+  integrity sha512-jWunZIgA1ocYtF6WGWg3EsPQD19FJ/QCSjiyzHIqVZez8EgFSRQ1iqnawVLOJCd2UA319ZOzjLcuUt6QO0IqRQ==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/util" "9.0.1"
+    "@substrate/ss58-registry" "^1.17.0"
 
 "@polkadot/rpc-augment@7.3.1":
   version "7.3.1"
@@ -1237,6 +1263,23 @@
     micro-base "^0.10.2"
     tweetnacl "^1.0.3"
 
+"@polkadot/util-crypto@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-9.0.1.tgz#4cfc867ebec1d593b351cf881e021364eff0c496"
+  integrity sha512-HPze3+VHY899B6CXwyrgWNDqmjmhfYy6+l29giXLfT/kmaL5FodRPCO36BNTbGCITuVajDR9wdZ/LeLZdIb79w==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@noble/hashes" "1.0.0"
+    "@noble/secp256k1" "1.5.5"
+    "@polkadot/networks" "9.0.1"
+    "@polkadot/util" "9.0.1"
+    "@polkadot/wasm-crypto" "^6.0.1"
+    "@polkadot/x-bigint" "9.0.1"
+    "@polkadot/x-randomvalues" "9.0.1"
+    "@scure/base" "1.0.0"
+    ed2curve "^0.3.0"
+    tweetnacl "^1.0.3"
+
 "@polkadot/util@8.3.1", "@polkadot/util@^8.3.1":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-8.3.1.tgz#64be69a6758c86aaa4ee136b8a59d94788b943d9"
@@ -1251,6 +1294,20 @@
     bn.js "^4.12.0"
     ip-regex "^4.3.0"
 
+"@polkadot/util@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-9.0.1.tgz#cedd3d44733df72245907eb13b86dafa32a52116"
+  integrity sha512-MuiuAb0VcnNpBFpbXZ4v0roxEVSpfx3bDR9qR31XCYCUODDKXa04srFz2EXI0pov087mTprIUE+x9wIWkH9QUg==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/x-bigint" "9.0.1"
+    "@polkadot/x-global" "9.0.1"
+    "@polkadot/x-textdecoder" "9.0.1"
+    "@polkadot/x-textencoder" "9.0.1"
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.2.0"
+    ip-regex "^4.3.0"
+
 "@polkadot/wasm-crypto-asmjs@^4.5.1":
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.5.1.tgz#e1025a49e106db11d1187caf65f56c960ea2ad2b"
@@ -1258,12 +1315,26 @@
   dependencies:
     "@babel/runtime" "^7.16.3"
 
+"@polkadot/wasm-crypto-asmjs@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.0.1.tgz#64a5ac84d3e7e23a57429fb8932e51161644d536"
+  integrity sha512-cSGsHBLfPW2nHztgZd+gisCoScA02jbAzwjop/b8xumQ2kq7yAed/K9G1lOQiofEKRetIJeqBzJyk0etopRORw==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
 "@polkadot/wasm-crypto-wasm@^4.5.1":
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.5.1.tgz#063a58ff7ddd939b7886a6a238109a8d2c416e46"
   integrity sha512-hPwke85HxpgG/RAlwdCE8u5w7bThvWg399mlB+XjogXMxOUWBZSgq2XYbgzROUXx27inK9nStF4Pnc4zJnqs9A==
   dependencies:
     "@babel/runtime" "^7.16.3"
+
+"@polkadot/wasm-crypto-wasm@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.0.1.tgz#d77033f184f46891411453d798a0d5f2e1129e88"
+  integrity sha512-0r/QgOjIyw4U0mLk6Tm97Di92uxcSPjTo7dK6tdXo1PwYouhzO5IJnL/jNgma8dm5hQoBhk7rcErmkh8c1kLFQ==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
 
 "@polkadot/wasm-crypto@^4.5.1":
   version "4.5.1"
@@ -1274,6 +1345,15 @@
     "@polkadot/wasm-crypto-asmjs" "^4.5.1"
     "@polkadot/wasm-crypto-wasm" "^4.5.1"
 
+"@polkadot/wasm-crypto@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-6.0.1.tgz#47e79133446f7c3e1afd35be844ce0e793b56bee"
+  integrity sha512-nW5DDrciHGbZbj0Xh7w0Bnh5exSJUw96Zux7RuGfXuoXXHZBcf0QiB4E2dcVh3d/NkF7PkB99FlkdQxQp4M0Rg==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/wasm-crypto-asmjs" "^6.0.1"
+    "@polkadot/wasm-crypto-wasm" "^6.0.1"
+
 "@polkadot/x-bigint@8.3.1":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-8.3.1.tgz#c010199c9d77739e1e4a95dd235d57cc0f74d07a"
@@ -1281,6 +1361,14 @@
   dependencies:
     "@babel/runtime" "^7.16.7"
     "@polkadot/x-global" "8.3.1"
+
+"@polkadot/x-bigint@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-9.0.1.tgz#8ce29cff85b0fcd088a3c1bc3dadc324afb66d88"
+  integrity sha512-At+huOL4WYdNh8PHy7r94y5JpilphsPLEuyM+K3M/aE2R9G/2f0qTK9AjHeyNyeIrhw6Bc4uzO5K2Ka72HjS2g==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/x-global" "9.0.1"
 
 "@polkadot/x-fetch@^8.3.1":
   version "8.3.1"
@@ -1299,6 +1387,13 @@
   dependencies:
     "@babel/runtime" "^7.16.7"
 
+"@polkadot/x-global@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-9.0.1.tgz#3fb9a6c9b8a86af542c4a514c0af4ba895a5ed5f"
+  integrity sha512-C4K3laEYWMlWc1fJFUC5Kd6gxSC0GIe/ajClPjiKf5cwCGkGgtkcB7uvpzvnMAdxYpXiUnMHbJB6X/QyV/VG+Q==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
 "@polkadot/x-randomvalues@8.3.1":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-8.3.1.tgz#a40ea594dad11566b9c0be9753fdad0f803888dd"
@@ -1306,6 +1401,14 @@
   dependencies:
     "@babel/runtime" "^7.16.7"
     "@polkadot/x-global" "8.3.1"
+
+"@polkadot/x-randomvalues@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-9.0.1.tgz#0cbd65817dfd4af3f99d8a3e7d9a456797bc25d9"
+  integrity sha512-F/1Eabzx9kWivSXA23SW5BzfjtDWqaNct+GkC5dlm2lg/iE2IRY2JIqoKKkfh1u1/3iQ5YfjA96NmD/swNAcew==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/x-global" "9.0.1"
 
 "@polkadot/x-textdecoder@8.3.1":
   version "8.3.1"
@@ -1315,6 +1418,14 @@
     "@babel/runtime" "^7.16.7"
     "@polkadot/x-global" "8.3.1"
 
+"@polkadot/x-textdecoder@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-9.0.1.tgz#dda6234550d770f34cbd12eb0ad9cf3efaf47dfe"
+  integrity sha512-SudTQiluYIRO8EXF02kfWZGfsXrvJq4D2yURiIeIeWbrAShRUcQES7W01iGa5xvaHSW249eJ3fHbeDTNQd5B6Q==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/x-global" "9.0.1"
+
 "@polkadot/x-textencoder@8.3.1":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-8.3.1.tgz#ad5eb021f851d3a64b443802f99f8d77db1629a1"
@@ -1322,6 +1433,14 @@
   dependencies:
     "@babel/runtime" "^7.16.7"
     "@polkadot/x-global" "8.3.1"
+
+"@polkadot/x-textencoder@9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-9.0.1.tgz#4013a5160a542472d5bdd94fb5b28b32f7e0bc9f"
+  integrity sha512-73LeTasA3iDJMCLQXZd21wzNjs1Xr2xNXW03Yja3OPLneGK6Zlqz77AAYcjhQd2dgSFoH2NQ1JvdffXT9y1sGA==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+    "@polkadot/x-global" "9.0.1"
 
 "@polkadot/x-ws@^8.3.1":
   version "8.3.1"
@@ -1495,10 +1614,20 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@scure/base@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
+  integrity sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
+"@substrate/ss58-registry@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.17.0.tgz#a6a50dbef67da0114aff7cdae7c6eec685c5983b"
+  integrity sha512-YdQOxCtEZLnYZFg/zSzfROYtvIs5+iLD7p/VHoll7AVEhrPAmxgF5ggMDB2Dass7dfwABVx7heATbPFNg95Q8w==
 
 "@surma/rollup-plugin-off-main-thread@^1.4.1":
   version "1.4.2"
@@ -1605,6 +1734,13 @@
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
   dependencies:
     "@types/node" "*"
 
@@ -2518,6 +2654,11 @@ bn.js@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+bn.js@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 body-parser@1.19.0:
   version "1.19.0"


### PR DESCRIPTION
This PR fixes an important flaw in the workflow:
**user may not have displayed mnemonic, and lose the chance of displaying mnemonic ever again**
fixes #164 
fixes #163 

Nazar suggested that we can store the mnemonic in the keychain, but I'm still favouring not storing the mnemonic at all. 
*And even if we decide to store the mnemonic in the keychain, it will be implemented later. And this problem needs to be addressed ASAP imo*. So, in short, this will either be a temporary solution, or a permanent one.

### Problem Description
1. user starts the app for the first time
2. proceeds to plotting screen
3. in plotting screen, the user does not display the intro (hence, mnemonic is not shown)
4. user quits the app for god knows why
5. when user re-opens the app, it goes directly to the dashboard, because the config is already created
6. there are no functionality to display mnemonic in the dashboard, and in order to have that, we have to store mnemonic

### Mindset behind this solution
In all the crypto-related apps I've seen that includes creating mnemonic:
**They are not starting the functionality before giving the mnemonic to the user**.
So, I decided to follow the same path. Imo, we should not start plotting/farming unless the user confirms on the mnemonic.

### The Solution
Moved the mnemonic confirmation modal to the end of the `SetupPlot` page.
Now, immediately after confirming the directory, a new modal pops up about mnemonic. And unless the user confirms that s/he copied the mnemonic, it is impossible to proceed into the `plotting` page.

If the user confirms the directory, but then quits the app without confirming the mnemonic modal, it does not matter :)
The app will start from scratch again, because neither node nor farmer had started.

**this new mnemonic modal is skipped totally if user imports reward address**

### What else changed?
To be able to get the mnemonic, we have to create the identity. So there is a new function in the backend just for creating an identity (we don't want to start node or farmer to just get the identity). 
`startNode` is not returning mnemonic anymore (it was a hacky solution anyway), it is the new `create_identity` functions responsibility.

The modal in the plotting screen is separated from the `next` button. Now its only purpose is to show hints. So there is new `hints` button in the plotting screen, which can be clicked unlimitedly. `next` button is disabled, and will be enabled only when plotting is finished.

In summary, we have a less complex and more direct workflow now.