### PR TITLE
address structure is fixed

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -43,28 +43,19 @@ fn plot_progress_tracker() -> usize {
 }
 
 #[tauri::command]
-async fn farming(path: String, reward_address: String, plot_size: u64) {
-    match reward_address.len() {
-        0 => {
-            farm(path.into(), "ws://127.0.0.1:9944", None, plot_size)
-                .await
-                .unwrap();
-        }
-        _ => {
-            if let Ok(address) = parse_reward_address(&reward_address) {
-                farm(path.into(), "ws://127.0.0.1:9944", Some(address), plot_size)
-                    .await
-                    .unwrap();
-            } else {
-                error!("Reward address could not be parsed!");
-            }
-        }
+async fn farming(path: String, reward_address: String, plot_size: u64) -> [u8; 32] {
+    if let Ok(address) = parse_reward_address(&reward_address) {
+        farm(path.into(), "ws://127.0.0.1:9944", Some(address), plot_size)
+            .await
+            .unwrap()
+    } else {
+        unreachable!("Reward address could not be parsed on the backend!")
     }
 }
 
 #[tauri::command]
-async fn start_node(path: String) -> [u8; 32] {
-    init_node(path.into()).await.unwrap()
+async fn start_node(path: String) {
+    init_node(path.into()).await.unwrap();
 }
 
 #[tauri::command]
@@ -164,10 +155,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn init_node(base_directory: PathBuf) -> Result<[u8; 32]> {
-    let identity = Identity::open_or_create(&base_directory)?;
-    let public_key = identity.public_key().to_bytes();
-
+async fn init_node(base_directory: PathBuf) -> Result<()> {
     let chain_spec =
         sc_service::GenericChainSpec::<subspace_runtime::GenesisConfig>::from_json_bytes(
             include_bytes!("../chain-spec.json").as_ref(),
@@ -188,7 +176,7 @@ async fn init_node(base_directory: PathBuf) -> Result<[u8; 32]> {
         }
     });
 
-    Ok(public_key)
+    Ok(())
 }
 
 /// Start farming by using plot in specified path and connecting to WebSocket server at specified
@@ -198,7 +186,7 @@ async fn farm(
     node_rpc_url: &str,
     reward_address: Option<PublicKey>,
     plot_size: u64,
-) -> Result<()> {
+) -> Result<[u8; 32]> {
     let identity = Identity::open_or_create(&base_directory)?;
     let address = identity.public_key().to_bytes().into();
 
@@ -260,7 +248,7 @@ async fn farm(
         plot.clone(),
         commitments.clone(),
         client.clone(),
-        identity,
+        identity.clone(),
         reward_address,
     );
 
@@ -286,7 +274,7 @@ async fn farm(
         }
     });
 
-    Ok(())
+    Ok(identity.public_key().to_bytes())
 }
 
 fn parse_reward_address(s: &str) -> Result<PublicKey, sp_core::crypto::PublicError> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -43,13 +43,15 @@ fn plot_progress_tracker() -> usize {
 }
 
 #[tauri::command]
-async fn farming(path: String, reward_address: String, plot_size: u64) -> [u8; 32] {
+async fn farming(path: String, reward_address: String, plot_size: u64) -> bool {
     if let Ok(address) = parse_reward_address(&reward_address) {
         farm(path.into(), "ws://127.0.0.1:9944", Some(address), plot_size)
             .await
-            .unwrap()
+            .unwrap();
+        true
     } else {
-        unreachable!("Reward address could not be parsed on the backend!")
+        // reward address could not be parsed, and farmer did not start
+        false
     }
 }
 
@@ -186,7 +188,7 @@ async fn farm(
     node_rpc_url: &str,
     reward_address: Option<PublicKey>,
     plot_size: u64,
-) -> Result<[u8; 32]> {
+) -> Result<()> {
     let identity = Identity::open_or_create(&base_directory)?;
     let address = identity.public_key().to_bytes().into();
 
@@ -274,7 +276,7 @@ async fn farm(
         }
     });
 
-    Ok(identity.public_key().to_bytes())
+    Ok(())
 }
 
 fn parse_reward_address(s: &str) -> Result<PublicKey, sp_core::crypto::PublicError> {

--- a/src/components/farmedList.vue
+++ b/src/components/farmedList.vue
@@ -98,13 +98,7 @@ export default defineComponent({
     displayRewardAddress() {
       const addr: string | null = LocalStorage.getItem("rewardAddress")
       if (addr == null) {
-        const config = appConfig.getAppConfig()
-        if (config) {
-          const { farmerPublicKey } = config.account
-          const addr2: string = addr ?? farmerPublicKey
-          return addr2
-        }
-        console.error("Cannot read config file to retrieve Public Key of the farmer")
+        console.error("Reward Address was null!")
         return "???"
       } else {
         return addr

--- a/src/components/farmedList.vue
+++ b/src/components/farmedList.vue
@@ -4,7 +4,6 @@ q-card(bordered flat)
     .row.items-center
       .col-auto.q-mr-sm
         .row.items-center
-          q-icon.q-mr-sm(color="grey" name="grid_view" size="40px")
           .text-h6.text-weight-light {{ lang.farmedBlocks }}:
       .col-auto.q-mr-xl
         h6 {{ farmedBlocksList?.length }}

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -50,20 +50,21 @@ export default defineComponent({
         return
       }
       console.log("toggle Clicked", this.launchOnStart)
-      if (this.launchOnStart)
+      if (this.launchOnStart) {
         Notify.create({
           message: lang.willAutoLaunch,
           icon: "info",
           group: 1,
           badgeStyle: "visibility:hidden;"
         })
-      else
+      } else {
         Notify.create({
           message: lang.willNotAutoLaunch,
           icon: "info",
           group: 1,
           badgeStyle: "visibility:hidden;"
         })
+      }
       if (this.launchOnStart) {
         await this.autoLauncher.enable()
       } else {
@@ -95,8 +96,7 @@ export default defineComponent({
     async initMenu() {
       if (this.autoLauncher.enabled != undefined) {
         this.launchOnStart = await this.autoLauncher.enabled
-      }
-      else {
+      } else {
         this.launchOnStart = false
         this.disableAutoLaunch = true
       }

--- a/src/lib/appConfig.ts
+++ b/src/lib/appConfig.ts
@@ -1,5 +1,5 @@
 import { LocalStorage } from "quasar"
-import { Account, AppConfig, Plot, emptyAppConfig, SegmentCache } from "./util"
+import { AppConfig, Plot, emptyAppConfig, SegmentCache } from "./util"
 
 export const appConfig = {
   initAppConfig(): void {
@@ -12,7 +12,6 @@ export const appConfig = {
   },
   updateAppConfig(
     plot: Plot | null,
-    account: Account | null,
     segmentCache: SegmentCache | null,
     launchOnBoot: boolean | null,
     importedRewAddr: boolean | null,
@@ -22,7 +21,6 @@ export const appConfig = {
     if (appConfig) {
       const newAppConfig = appConfig
       if (plot) newAppConfig.plot = plot
-      if (account) newAppConfig.account = account
       if (segmentCache) newAppConfig.segmentCache = segmentCache
       if (launchOnBoot != null) newAppConfig.launchOnBoot = launchOnBoot
       if (importedRewAddr != null) newAppConfig.importedRewAddr = importedRewAddr

--- a/src/lib/autoLauncher.ts
+++ b/src/lib/autoLauncher.ts
@@ -105,22 +105,31 @@ const winAL = {
   async enable({ appName, appPath, minimized }: AutoLaunchParams): Promise<ChildReturnData> {
     const returnVal = <ChildReturnData>{ stdout: [], stderr: [] }
     const result = await native.winregSet(this.subKey, appName, appPath)
-    if (result.search('success') > -1) returnVal.stdout.push(result)
-    else returnVal.stderr.push(result)
+    if (result.search('success') > -1) {
+      returnVal.stdout.push(result)
+    } else {
+      returnVal.stderr.push(result)
+    }
     return returnVal
   },
   async disable(appName: string): Promise<ChildReturnData> {
     const returnVal = <ChildReturnData>{ stdout: [], stderr: [] }
     const result = <string>(await native.winregDelete(this.subKey, appName))
-    if (result.search('success') > -1) returnVal.stdout.push(result)
-    else returnVal.stderr.push(result)
+    if (result.search('success') > -1) {
+      returnVal.stdout.push(result)
+    } else {
+      returnVal.stderr.push(result)
+    }
     return returnVal
   },
   async isEnabled(appName: string): Promise<boolean> {
     const result = <string>(await native.winregGet(this.subKey, appName))
     console.log('isEnabled result:', result);
-    if (result.search('The system cannot find the file specified.') > -1) return false
-    else return true
+    if (result.search('The system cannot find the file specified.') > -1) {
+      return false
+    } else {
+      return true
+    }
   }
 }
 
@@ -138,15 +147,21 @@ export class AutoLauncher {
   async enable(): Promise<void | ChildReturnData> {
     const child = await this.autoLauncher.enable({ appName: this.appName, appPath: this.appPath, minimized: true })
     this.enabled = await this.isEnabled()
-    if (this.enabled == false) console.log("ENABLE DID NOT WORK")
-    else appConfig.updateAppConfig(null, null, null, true, null, null)
+    if (this.enabled == false) {
+      console.error("ENABLE DID NOT WORK")
+    } else {
+      appConfig.updateAppConfig(null, null, null, true, null, null)
+    }
     return child
   }
   async disable(): Promise<void | ChildReturnData> {
     const child = this.autoLauncher.disable(this.appName)
     this.enabled = await this.isEnabled()
-    if (this.enabled == true) console.log("DISABLE DID NOT WORK")
-    else appConfig.updateAppConfig(null, null, null, false, null, null)
+    if (this.enabled == true) {
+      console.error("DISABLE DID NOT WORK")
+    } else {
+      appConfig.updateAppConfig(null, null, null, false, null, null)
+    }
     return child
   }
   async init(): Promise<void> {
@@ -155,14 +170,16 @@ export class AutoLauncher {
     console.log("OS TYPE: " + osType)
     this.appPath = await invoke('get_this_binary') as string
     console.log('get_this_binary', this.appPath);
-    if (osType == 'Darwin') this.autoLauncher = macAL
-    else if (osType == 'Windows_NT') {
+    if (osType == 'Darwin') {
+      this.autoLauncher = macAL
+    } else if (osType == 'Windows_NT') {
       this.autoLauncher = winAL
       // From Windows 11 Tests: get_this_binary returns a string with a prefix "\\?\" on C:\Users......". On boot, autostart can't locate "\\?\c:\DIR\subspace-desktop.exe
       const appPath = this.appPath
       this.appPath = appPath.startsWith("\\\\?\\") ? appPath.replace("\\\\?\\", "") : appPath
+    } else {
+      this.autoLauncher = linAL
     }
-    else this.autoLauncher = linAL
 
     const config = appConfig.getAppConfig()
     if (config) {

--- a/src/lib/autoLauncher.ts
+++ b/src/lib/autoLauncher.ts
@@ -150,7 +150,7 @@ export class AutoLauncher {
     if (this.enabled == false) {
       console.error("ENABLE DID NOT WORK")
     } else {
-      appConfig.updateAppConfig(null, null, null, true, null, null)
+      appConfig.updateAppConfig(null, null, true, null, null)
     }
     return child
   }
@@ -160,7 +160,7 @@ export class AutoLauncher {
     if (this.enabled == true) {
       console.error("DISABLE DID NOT WORK")
     } else {
-      appConfig.updateAppConfig(null, null, null, false, null, null)
+      appConfig.updateAppConfig(null, null, false, null, null)
     }
     return child
   }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -14,7 +14,6 @@ import {
   emptyClientData,
   NetStatus,
   FarmedBlock,
-  ClientIdentity,
   SubPreDigest
 } from "src/lib/types"
 import { appConfig } from "./appConfig"
@@ -206,26 +205,19 @@ export class Client {
   }
 
   /* NODE INTEGRATION */
-  public async waitNodeStartApiConnect(path: string): Promise<ClientIdentity> {
-    const clientIdentity = await this.startNode(path)
+  public async waitNodeStartApiConnect(path: string): Promise<void> {
+    await this.startNode(path)
     // TODO: workaround in case node takes some time to fully start.
     await new Promise((resolve) => setTimeout(resolve, 7000))
     await this.connectLocalApi()
-    return clientIdentity
   }
 
   // TODO: Disable mnemonic return from tauri commmand instead of this validation.
-  private async startNode(path: string): Promise<ClientIdentity> {
-    const publicKey = await tauri.invoke("start_node", { path })
-    const farmerPublicKey: AccountId32 = this.localApi.registry.createType(
-      "AccountId32",
-      publicKey
-    )
-
+  private async startNode(path: string): Promise<void> {
+    await tauri.invoke("start_node", { path })
     if (!this.firstLoad) {
       this.loadStoredBlocks()
     }
-    return { publicKey: farmerPublicKey }
   }
 
   private loadStoredBlocks(): void {
@@ -243,7 +235,7 @@ export class Client {
   }
 
   /* FARMER INTEGRATION */
-  public async startFarming(path: string, plotSizeGB: number): Promise<void> {
+  public async startFarming(path: string, plotSizeGB: number): Promise<string> {
     const plotSize = Math.round(plotSizeGB * 1048576)
     const rewardAddress = LocalStorage.getItem("rewardAddress")?.toString() || ""
     return await tauri.invoke("farming", { path, rewardAddress, plotSize })

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -85,8 +85,10 @@ export class Client {
                   // TODO
                 }
               })
-              const addr: string | null = LocalStorage.getItem("rewardAddress")
-              const addr2: string = addr ?? farmerPublicKey
+              const addr_unchecked: string | null = LocalStorage.getItem("rewardAddress")
+              let addr!: string;
+              if (addr_unchecked) addr = addr_unchecked
+              else console.log("Error: Reward Address should not be null!")
               const block: FarmedBlock = {
                 author: farmerPublicKey,
                 id: hash.toString(),
@@ -95,7 +97,7 @@ export class Client {
                 blockNum,
                 blockReward,
                 feeReward: 0,
-                rewardAddr: addr2,
+                rewardAddr: addr,
                 appsLink: appsLink + blockNum.toString()
               }
               this.data.farming.farmed = [block].concat(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -85,26 +85,27 @@ export class Client {
                   // TODO
                 }
               })
-              const addr_unchecked: string | null = LocalStorage.getItem("rewardAddress")
-              let addr!: string;
-              if (addr_unchecked) addr = addr_unchecked
-              else console.log("Error: Reward Address should not be null!")
-              const block: FarmedBlock = {
-                author: farmerPublicKey,
-                id: hash.toString(),
-                time: Date.now(),
-                transactions: 0,
-                blockNum,
-                blockReward,
-                feeReward: 0,
-                rewardAddr: addr,
-                appsLink: appsLink + blockNum.toString()
+              const addr: string | null = LocalStorage.getItem("rewardAddress")
+              if (addr) {
+                const block: FarmedBlock = {
+                  author: farmerPublicKey,
+                  id: hash.toString(),
+                  time: Date.now(),
+                  transactions: 0,
+                  blockNum,
+                  blockReward,
+                  feeReward: 0,
+                  rewardAddr: addr,
+                  appsLink: appsLink + blockNum.toString()
+                }
+                this.data.farming.farmed = [block].concat(
+                  this.data.farming.farmed
+                )
+                storeBlocks(this.data.farming.farmed)
+                this.data.farming.events.emit("farmedBlock", block)
+              } else {
+                console.error("CLIENT: Reward address was null!")
               }
-              this.data.farming.farmed = [block].concat(
-                this.data.farming.farmed
-              )
-              storeBlocks(this.data.farming.farmed)
-              this.data.farming.events.emit("farmedBlock", block)
             }
             this.data.farming.events.emit("newBlock", blockNum)
           }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,10 +78,6 @@ export interface ClientData {
   farming: ClientFarming
 }
 
-export interface ClientIdentity {
-  publicKey: AccountId32
-}
-
 export const emptyClientData: ClientData = {
   plot: { details: {}, plotFile: "", plotSizeGB: 0, status: "" },
   farming: { farmed: [], status: "", events: mitt() },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,6 @@ import type { AccountId32 } from "@polkadot/types/interfaces"
 import type { Struct, u64 } from "@polkadot/types"
 
 export interface FarmedBlock {
-  author: string
   blockNum: number
   time: number
   transactions: number

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -41,7 +41,6 @@ export async function resetAndClear(): Promise<void> {
 export interface AppConfig {
   [index: string]: any
   plot: Plot
-  account: Account
   segmentCache: SegmentCache
   launchOnBoot: boolean
   importedRewAddr: boolean
@@ -52,9 +51,6 @@ export interface SegmentCache {
   networkSegmentCount: number
   blockchainSizeGB: number
 }
-export interface Account {
-  farmerPublicKey: string
-}
 export interface Plot {
   location: string
   sizeGB: number
@@ -62,7 +58,6 @@ export interface Plot {
 
 export const emptyAppConfig: AppConfig = {
   plot: { location: "", sizeGB: 0 },
-  account: { farmerPublicKey: "" },
   segmentCache: { networkSegmentCount: 0, blockchainSizeGB: 0 },
   launchOnBoot: true,
   importedRewAddr: false,

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -82,7 +82,10 @@ export default defineComponent({
       raceResult.then(async() => {
         if (this.client.isFirstLoad() === false) {
           await this.client.waitNodeStartApiConnect(config.plot.location)
-          await this.client.startFarming(config.plot.location, config.plot.sizeGB)
+          const farmerStarted = await this.client.startFarming(config.plot.location, config.plot.sizeGB)
+          if (!farmerStarted) {
+            console.error("DASHBOARD | Farmer start error!")
+          }
           await this.client.startBlockSubscription()
         }
 

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -101,7 +101,7 @@ export default defineComponent({
         await this.client.disconnectPublicApi()
       })
       raceResult.catch(_ => {
-        console.log("The server seems to be too congested! Please try again later...")
+        console.error("The server seems to be too congested! Please try again later...")
       })
     } else {
       console.error("DASH MOUNTED | ERROR | NO CONFIG LOADED")

--- a/src/pages/ImportKey.vue
+++ b/src/pages/ImportKey.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     },
     async importKey() {
       LocalStorage.set("rewardAddress", this.rewardAddress)
-      appConfig.updateAppConfig(null, null, null, null, true, null)
+      appConfig.updateAppConfig(null, null, null, true, null)
       this.$router.replace({ name: "setupPlot" })
     },
     skip() {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -85,7 +85,7 @@ export default defineComponent({
         }, null, null, null)
       })
       raceResult.catch(_ => {
-        console.log("The server seems to be too congested! Please try again later...")
+        console.error("The server seems to be too congested! Please try again later...")
       })
     }
   }

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -81,7 +81,7 @@ export default defineComponent({
         await this.client.disconnectPublicApi()
         const totalSize = networkSegmentCount * 256 * util.PIECE_SIZE
         const blockchainSizeGB = Math.round((totalSize * 100) / util.GB) / 100
-        appConfig.updateAppConfig(null, null, {
+        appConfig.updateAppConfig(null, {
           networkSegmentCount,
           blockchainSizeGB: blockchainSizeGB === 0 ? 0.1 : blockchainSizeGB
         }, null, null, null)

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -220,11 +220,9 @@ export default defineComponent({
       const config = appConfig.getAppConfig()
       if (config) {
         await this.client.startBlockSubscription()
-        const publicKey = await this.client.startFarming(this.plotDirectory, config.plot.sizeGB)
-        if (publicKey) {
-          appConfig.updateAppConfig(null, { farmerPublicKey: publicKey.toString() }, null, null, null, true)
-        } else {
-          console.error("NO PUBLIC KEY RETURNED FROM FARMER")
+        const farmerStarted = await this.client.startFarming(this.plotDirectory, config.plot.sizeGB)
+        if (!farmerStarted) {
+          console.error("PLOTTING PROGRESS | Farmer start error!")
         }
         const networkSegmentCount = config.segmentCache.networkSegmentCount
         this.networkSegmentCount = networkSegmentCount

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -209,23 +209,7 @@ export default defineComponent({
       }
     },
     async waitNode() {
-      const { publicKey } = await this.client.waitNodeStartApiConnect(
-        this.plotDirectory
-      )
-      if (publicKey) {
-        const config = appConfig.getAppConfig()
-        if (config) {
-          appConfig.updateAppConfig(
-            null,
-            {
-              farmerPublicKey: publicKey.toString()
-            },
-            null, null, null, null
-          )
-        }
-      } else {
-        console.error("PLOT PROGRESS | ERROR | NO PUBLIC KEY")
-      }
+      await this.client.waitNodeStartApiConnect(this.plotDirectory)
     },
     pausePlotting() {
       this.plotFinished = true
@@ -235,7 +219,9 @@ export default defineComponent({
       const config = appConfig.getAppConfig()
       if (config) {
         await this.client.startBlockSubscription()
-        await this.client.startFarming(this.plotDirectory, config.plot.sizeGB)
+        const publicKey = await this.client.startFarming(this.plotDirectory, config.plot.sizeGB)
+        if (publicKey) appConfig.updateAppConfig(null, { farmerPublicKey: publicKey.toString() }, null, null, null, true)
+        else console.log("NO PUBLIC KEY RETURNED FROM FARMER")
         const networkSegmentCount = config.segmentCache.networkSegmentCount
         this.networkSegmentCount = networkSegmentCount
         this.plottingData.allocatedGB = config.plot.sizeGB
@@ -245,7 +231,6 @@ export default defineComponent({
           this.localSegmentCount = await this.client.getLocalSegmentCount()
         } while (this.localSegmentCount < this.networkSegmentCount)
       }
-      appConfig.updateAppConfig(null, null, null, null, null, true)
     },
     startTimers() {
       farmerTimer = window.setInterval(() => {

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -178,10 +178,11 @@ export default defineComponent({
         this.plottingData.finishedGB = this.plottingData.allocatedGB
     },
     localSegmentCount(localCount) {
-      if (localCount >= this.networkSegmentCount)
+      if (localCount >= this.networkSegmentCount) {
         this.plottingData.status = `Archived ${localCount.toLocaleString()} Segments`
-      else
+      } else {
         this.plottingData.status = `Archived ${localCount.toLocaleString()} of ${this.networkSegmentCount.toLocaleString()} Segments`
+      }
 
       this.plottingData.finishedGB =
         (localCount * this.plottingData.allocatedGB) / this.networkSegmentCount
@@ -220,8 +221,11 @@ export default defineComponent({
       if (config) {
         await this.client.startBlockSubscription()
         const publicKey = await this.client.startFarming(this.plotDirectory, config.plot.sizeGB)
-        if (publicKey) appConfig.updateAppConfig(null, { farmerPublicKey: publicKey.toString() }, null, null, null, true)
-        else console.log("NO PUBLIC KEY RETURNED FROM FARMER")
+        if (publicKey) {
+          appConfig.updateAppConfig(null, { farmerPublicKey: publicKey.toString() }, null, null, null, true)
+        } else {
+          console.error("NO PUBLIC KEY RETURNED FROM FARMER")
+        }
         const networkSegmentCount = config.segmentCache.networkSegmentCount
         this.networkSegmentCount = networkSegmentCount
         this.plottingData.allocatedGB = config.plot.sizeGB

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -282,7 +282,7 @@ export default defineComponent({
         this.plotDirectory.slice(-1)
 
       await appData.createCustomDataDir(this.plotDirectory)
-      appConfig.updateAppConfig({ location: this.plotDirectory, sizeGB: this.allocatedGB }, null, null, null, null, null)
+      appConfig.updateAppConfig({ location: this.plotDirectory, sizeGB: this.allocatedGB }, null, null, null, null)
 
       await this.checkIdentity()
     },
@@ -307,7 +307,7 @@ export default defineComponent({
     async viewMnemonic() {
       const modal = await util.showModal(mnemonicModal)
       modal?.onDismiss(() => {
-        appConfig.updateAppConfig(null, null, null, null, true, null)
+        appConfig.updateAppConfig(null, null, null, true, null)
         this.$router.replace({ name: "plottingProgress" })
       })
     }

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -304,6 +304,7 @@ export default defineComponent({
     async viewMnemonic() {
       const modal = await util.showModal(mnemonicModal)
       modal?.onDismiss(() => {
+        appConfig.updateAppConfig(null, null, null, null, true, null)
         this.$router.replace({ name: "plottingProgress" })
       })
     }

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -177,8 +177,11 @@ export default defineComponent({
       const utilizedGB = util.toFixed(totalDiskSizeGB - safeAvailableGB, 2)
       const freeGB = ((): number => {
         const val = util.toFixed(safeAvailableGB - this.allocatedGB, 2)
-        if (val >= 0) return val
-        else return 0
+        if (val >= 0) {
+          return val
+        } else {
+          return 0
+        }
       })()
 
       return {


### PR DESCRIPTION
This PR revamps the address structure (publicKey and rewardAddress). 

Changes:
- the farmer returns the publicKey instead of the node
- and since we unified the workflow of providing a reward address always to the farmer, `farming` function is also simplified.
- Node does not return anything anymore. 
- the publicKey address formatting on the frontend is simplified.
- reward address related optimizations on frontend