### PR TITLE
disabled reset button on prod

### DIFF
--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -12,7 +12,7 @@ q-menu(auto-close)
         .col
           p.text-grey(v-if="!launchOnStart") {{ lang.autoStart }}
           p.text-black(v-else) {{ lang.autoStart }}
-    q-item(@click="reset()" clickable)
+    q-item(@click="reset()" clickable v-if="devMode")
       .row.items-center
         .col-auto.q-mr-md
           q-icon(color="red" name="refresh")
@@ -34,13 +34,19 @@ export default defineComponent({
       lang,
       launchOnStart: false,
       autoLauncher: global.autoLauncher,
-      disableAutoLaunch: false
+      disableAutoLaunch: false,
+      devMode: false
     }
   },
   mounted() {
+    this.checkDev()
     this.initMenu()
   },
   methods: {
+    checkDev() {
+      if (util.CONTEXT_MENU != "OFF")
+        this.devMode = true
+    },
     async toggleClicked() {
       if (this.disableAutoLaunch) {
         Notify.create({


### PR DESCRIPTION
Disables the `reset` button from the main menu (which removes everything and basically performs a soft uninstall-reinstall) for the production mode. And keeps it only for the dev mode.

The motivation behind this is: and accidental click on this button (although there is a confirmation screen) can be very upsetting for the end users, and it serves more purpose for the dev env.