### PR TITLE
version bump to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-desktop",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "Subspace desktop",
   "author": "Subspace Labs <https://subspace.network>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9498,7 +9498,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-desktop"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "dotenv",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-desktop"
-version = "0.4.1"
+version = "0.4.2"
 description = "Subspace desktop"
 authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
After fixing the bugs on 0.4.1, lets bump the version and release a stable one.

Multi-replica release may take time to become stable, so this is a good stepping stone between stable releases