### PR TITLE
better logging, and logic fix

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -59,6 +59,7 @@ export default defineComponent({
   mounted() {
     this.nodeNameChanger()
     this.appVersion = (process.env.APP_VERSION as string)
+    util.infoLogger("Version: " + this.appVersion)
 
   },
   methods: {

--- a/src/lib/autoLauncher.ts
+++ b/src/lib/autoLauncher.ts
@@ -174,7 +174,7 @@ export class AutoLauncher {
       this.enabled = await this.isEnabled()
       trial += 1
     } while (this.enabled && trial < 5);
-    await appConfig.update({launchOnBoot: false})
+    await appConfig.update({ launchOnBoot: false })
     return child
   }
   async init(): Promise<void> {

--- a/src/pages/ImportKey.vue
+++ b/src/pages/ImportKey.vue
@@ -58,7 +58,7 @@ export default defineComponent({
       }
     },
     async importKey() {
-      appConfig.update({ rewardAddress: this.rewardAddress })
+      await appConfig.update({ rewardAddress: this.rewardAddress })
       this.$router.replace({ name: "setupPlot" })
     },
     skip() {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -49,10 +49,10 @@ export default defineComponent({
         this.dashboard()
         return
       }
-      // validate returned false, means we are starting from scratch
+      util.infoLogger("validate failed, we should start from scratch")
       this.firstLoad()
     } catch (e) {
-      // config.read() failed, means we are starting from scratch
+      util.infoLogger("config could not be read, starting from scratch")
       this.firstLoad()
     }
   },
@@ -67,7 +67,8 @@ export default defineComponent({
       this.$router.replace({ name: "dashboard" })
     },
     async firstLoad() {
-      util.infoLogger("INDEX | First Time RUN.")
+      util.infoLogger("INDEX | First Time RUN, resetting reward address")
+      await appConfig.update({ rewardAddress: "" })
       this.loadNetworkData()
       const config = await appConfig.read()
       if (config.launchOnBoot) {
@@ -84,7 +85,7 @@ export default defineComponent({
         await this.client.disconnectPublicApi()
         const totalSize = networkSegmentCount * 256 * util.PIECE_SIZE
         const blockchainSizeGB = Math.round((totalSize * 100) / util.GB) / 100
-        appConfig.update({ segmentCache: {
+        await appConfig.update({ segmentCache: {
           networkSegmentCount,
           blockchainSizeGB: blockchainSizeGB === 0 ? 0.1 : blockchainSizeGB
         }})

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -309,13 +309,16 @@ export default defineComponent({
       }
       else {
         util.infoLogger("SETUP PLOT | reward address was initialized before, proceeding to plotting")
+        await appConfig.update({
+          plot: { location: this.plotDirectory, sizeGB: this.allocatedGB },
+        })
         this.$router.replace({ name: "plottingProgress" })
       }
     },
     async viewMnemonic() {
       const modal = await util.showModal(mnemonicModal)
-      modal?.onDismiss(() => {
-        appConfig.update({
+      modal?.onDismiss(async () => {
+        await appConfig.update({
           plot: { location: this.plotDirectory, sizeGB: this.allocatedGB },
           rewardAddress: this.rewardAddress
         })


### PR DESCRIPTION
This PR:
- improves the logging messages
- puts some forgotten `await`s in place related to `config.update`
- when imported mnemonic, or when there is a leftover reward address from previous run, it was not setting/updating `plot` config, this is fixed now. This issue is present in main, and also in 0.4.8.

Fixes #203 