### PR TITLE
Persistent node name

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mitt": "^3.0.0",
     "process": "^0.11.10",
     "quasar": "^2.0.0",
+    "random-word-slugs": "^0.1.6",
     "vue-router": "^4.0.0",
     "vue3-apexcharts": "^1.4.1"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5281,15 +5281,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "names"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8690bf09abf659851e58cd666c3d37ac6af07c2bd7a9e332cfba471715775"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9382,7 +9373,6 @@ dependencies = [
  "fs2",
  "hex",
  "log",
- "names",
  "sc-chain-spec",
  "sc-executor",
  "sc-network",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,6 @@ fdlimit = "0.2.1"
 fs2 = "0.4.3"
 hex = "0.4.3"
 log = "0.4.14"
-names = { version = "0.12.0", default-features = false }
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d", features = ["wasmtime"] }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate", rev = "c4f3d028621edb293d2c423516221aa396f76a2d" }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,6 @@ mod node;
 
 use anyhow::Result;
 use log::{debug, error, info, LevelFilter};
-use node::generate_node_name;
 use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -64,11 +63,6 @@ async fn farming(path: String, reward_address: String, plot_size: u64) -> bool {
         // reward address could not be parsed, and farmer did not start
         false
     }
-}
-
-#[tauri::command]
-fn init_node_name() -> String {
-    generate_node_name()
 }
 
 #[tauri::command]
@@ -135,8 +129,7 @@ async fn main() -> Result<()> {
                 plot_progress_tracker,
                 start_node,
                 frontend_error_logger,
-                frontend_info_logger,
-                init_node_name
+                frontend_info_logger
             ],
             #[cfg(target_os = "windows")]
             tauri::generate_handler![
@@ -149,8 +142,7 @@ async fn main() -> Result<()> {
                 plot_progress_tracker,
                 start_node,
                 frontend_error_logger,
-                frontend_info_logger,
-                init_node_name
+                frontend_info_logger
             ],
         )
         .build(tauri::generate_context!())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ mod node;
 
 use anyhow::Result;
 use log::{debug, error, info, LevelFilter};
+use node::generate_node_name;
 use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -66,12 +67,13 @@ async fn farming(path: String, reward_address: String, plot_size: u64) -> bool {
 }
 
 #[tauri::command]
-async fn start_node(path: String) -> String {
-    let node_name = node::generate_node_name();
-    node::init_node(path.into(), node_name.clone())
-        .await
-        .unwrap();
-    node_name
+fn init_node_name() -> String {
+    generate_node_name()
+}
+
+#[tauri::command]
+async fn start_node(path: String, node_name: String) {
+    node::init_node(path.into(), node_name).await.unwrap();
 }
 
 #[tauri::command]
@@ -133,7 +135,8 @@ async fn main() -> Result<()> {
                 plot_progress_tracker,
                 start_node,
                 frontend_error_logger,
-                frontend_info_logger
+                frontend_info_logger,
+                init_node_name
             ],
             #[cfg(target_os = "windows")]
             tauri::generate_handler![
@@ -146,7 +149,8 @@ async fn main() -> Result<()> {
                 plot_progress_tracker,
                 start_node,
                 frontend_error_logger,
-                frontend_info_logger
+                frontend_info_logger,
+                init_node_name
             ],
         )
         .build(tauri::generate_context!())

--- a/src-tauri/src/node.rs
+++ b/src-tauri/src/node.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use log::{error, warn};
-use names::{Generator, Name};
 use sc_chain_spec::ChainSpec;
 use sc_executor::NativeExecutionDispatch;
 use sc_executor::WasmExecutionMethod;
@@ -24,7 +23,6 @@ use tokio::runtime::Handle;
 static INITIALIZE_SUBSTRATE: Once = Once::new();
 
 /// The maximum number of characters for a node name.
-const NODE_NAME_MAX_LENGTH: usize = 64;
 
 /// Default sub directory to store network config.
 const DEFAULT_NETWORK_CONFIG_PATH: &str = "network";
@@ -253,19 +251,5 @@ fn database_config(base_path: &Path, cache_size: usize, role: &Role) -> Database
         paritydb_path,
         rocksdb_path,
         cache_size,
-    }
-}
-
-/// Generate a valid random name for the node
-pub fn generate_node_name() -> String {
-    loop {
-        let node_name = Generator::with_naming(Name::Numbered)
-            .next()
-            .expect("RNG is available on all supported platforms; qed");
-        let count = node_name.chars().count();
-
-        if count < NODE_NAME_MAX_LENGTH {
-            return node_name;
-        }
     }
 }

--- a/src/lib/appConfig.ts
+++ b/src/lib/appConfig.ts
@@ -18,6 +18,7 @@ interface Config {
   rewardAddress: string,
   launchOnBoot: boolean,
   version: string,
+  nodeName: string,
 
   // TODO: remove this after PlottingProgress refactoring
   segmentCache: SegmentCache,
@@ -28,6 +29,7 @@ const emptyConfig: Config = {
   rewardAddress: "",
   launchOnBoot: true,
   version: process.env.APP_VERSION as string,
+  nodeName: "",
   segmentCache: { networkSegmentCount: 0, blockchainSizeGB: 0 },
 }
 
@@ -51,12 +53,14 @@ export const appConfig = {
       await this.write(emptyConfig)
     }
   },
-  validate(config: Config): boolean {
-    const { plot, rewardAddress } = config
+  async validate(): Promise<boolean> {
+    const config = await this.read()
+    const { plot, rewardAddress, nodeName } = config
     if (
       plot.location.length > 0 &&
       plot.sizeGB > 0 &&
-      rewardAddress.length > 0
+      rewardAddress.length > 0 &&
+      nodeName.length > 0
     ) {
       return true
     }
@@ -93,25 +97,27 @@ export const appConfig = {
       launchOnBoot,
       rewardAddress,
       version,
+      nodeName,
       segmentCache,
     }: {
       plot?: Plot;
       launchOnBoot?: boolean;
       rewardAddress?: string;
       version?: string;
+      nodeName?: string;
       segmentCache?: SegmentCache;
     }
   ): Promise<void> {
     const newAppConfig = await this.read()
-    if (plot) newAppConfig.plot = plot
+    if (plot !== undefined) newAppConfig.plot = plot
     if (launchOnBoot !== undefined) newAppConfig.launchOnBoot = launchOnBoot
-    if (rewardAddress) newAppConfig.rewardAddress = rewardAddress
-    if (version) newAppConfig.version = version
-    if (segmentCache) newAppConfig.segmentCache = segmentCache
-    this.write(newAppConfig)
+    if (rewardAddress !== undefined) newAppConfig.rewardAddress = rewardAddress
+    if (version !== undefined) newAppConfig.version = version
+    if (nodeName !== undefined) newAppConfig.nodeName = nodeName
+    if (segmentCache !== undefined) newAppConfig.segmentCache = segmentCache
+    await this.write(newAppConfig)
   },
   showErrorModal(): DialogChainObject {
-    // TODO: refactor this!
     return Dialog.create({ message: "Config file is corrupted, resetting..." })
   }
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -218,10 +218,6 @@ export class Client {
     }
   }
 
-  public async generateNodeName(): Promise<string> {
-    return await tauri.invoke("init_node_name")
-  }
-
   private loadStoredBlocks(): void {
     this.farmed = getStoredBlocks()
     this.data.farming.farmed = this.farmed

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -202,20 +202,24 @@ export class Client {
   }
 
   /* NODE INTEGRATION */
-  public async waitNodeStartApiConnect(path: string): Promise<void> {
-    await this.startNode(path)
+  public async waitNodeStartApiConnect(path: string, nodeName: string): Promise<void> {
+    await this.startNode(path, nodeName)
     // TODO: workaround in case node takes some time to fully start.
     await new Promise((resolve) => setTimeout(resolve, 7000))
     await this.connectLocalApi()
   }
 
   // TODO: Disable mnemonic return from tauri commmand instead of this validation.
-  private async startNode(path: string): Promise<void> {
-    const nodeName: string = await tauri.invoke("start_node", { path })
+  private async startNode(path: string, nodeName: string): Promise<void> {
+    await tauri.invoke("start_node", { path, nodeName })
     myEmitter.emit("nodeName", nodeName)
     if (!this.firstLoad) {
       this.loadStoredBlocks()
     }
+  }
+
+  public async generateNodeName(): Promise<string> {
+    return await tauri.invoke("init_node_name")
   }
 
   private loadStoredBlocks(): void {
@@ -237,7 +241,7 @@ export class Client {
   public async startFarming(path: string, plotSizeGB: number): Promise<boolean> {
     const plotSize = Math.round(plotSizeGB * 1048576)
     const rewardAddress: string = (await appConfig.read()).rewardAddress
-    if (!rewardAddress) {
+    if (rewardAddress === "") {
       util.errorLogger("Tried to send empty reward address to backend!")
     }
     return await tauri.invoke("farming", { path, rewardAddress, plotSize })

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -9,7 +9,9 @@ import { ApiPromise, WsProvider } from "@polkadot/api"
 import { RegistryTypes } from "@polkadot/types-codec/types"
 import { appData } from "./appData"
 import { appConfig } from "./appConfig"
+import { generateSlug } from "random-word-slugs"
 
+const nodeNameMaxLength = 64
 export const appName: string = process.env.APP_NAME || "subspace-desktop"
 
 export const random = (min: number, max: number): number =>
@@ -117,4 +119,15 @@ export function createApi(url: string | string[], types?: RegistryTypes): ApiPro
     provider: new WsProvider(url, false),
     types
   });
+}
+
+export function generateNodeName(): string {
+  while (true) {
+    const slug = generateSlug(2)
+    const num = Math.floor(Math.random() * (9999 - 1000 + 1)) + 1000;
+    const nodeName = slug + "-" + num.toString()
+    if (nodeName.length < 64) {
+      return nodeName
+    }
+  }
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -122,12 +122,11 @@ export function createApi(url: string | string[], types?: RegistryTypes): ApiPro
 }
 
 export function generateNodeName(): string {
-  while (true) {
+  let nodeName = ""
+  do {
     const slug = generateSlug(2)
     const num = Math.floor(Math.random() * (9999 - 1000 + 1)) + 1000;
-    const nodeName = slug + "-" + num.toString()
-    if (nodeName.length < 64) {
-      return nodeName
-    }
-  }
+    nodeName = slug + "-" + num.toString()
+  } while (nodeName.length > nodeNameMaxLength)
+  return nodeName
 }

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -80,7 +80,11 @@ export default defineComponent({
     raceResult.then(async() => {
       if (this.$client.isFirstLoad() === false) {
         util.infoLogger("DASHBOARD | starting node")
-        await this.$client.waitNodeStartApiConnect(config.plot.location)
+        if (config.nodeName !== "") {
+          await this.$client.waitNodeStartApiConnect(config.plot.location, config.nodeName)
+        } else {
+          util.errorLogger("DASHBOARD | node name was empty when tried to start node")
+        }
         util.infoLogger("DASHBOARD | starting farmer")
         const farmerStarted = await this.$client.startFarming(config.plot.location, config.plot.sizeGB)
         if (!farmerStarted) {
@@ -104,8 +108,9 @@ export default defineComponent({
       await this.checkFarmerAndPlot()
       await this.$client.disconnectPublicApi()
     })
-    raceResult.catch(_ => {
-      util.errorLogger("The server seems to be too congested! Please try again later...")
+    raceResult.catch((error) => {
+      util.errorLogger(error)
+      util.errorLogger("DASHBOARD | could not connect to server")
     })
   },
   unmounted() {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -43,8 +43,7 @@ export default defineComponent({
   async mounted() {
     try {
       this.checkDev()
-      const config = await appConfig.read()
-      if (appConfig.validate(config)) {
+      if (await appConfig.validate()) {
         util.infoLogger("INDEX | NOT First Time RUN.")
         this.dashboard()
         return
@@ -90,8 +89,9 @@ export default defineComponent({
           blockchainSizeGB: blockchainSizeGB === 0 ? 0.1 : blockchainSizeGB
         }})
       })
-      raceResult.catch(() => {
-        util.errorLogger("The server seems to be too congested! Please try again later...")
+      raceResult.catch((error) => {
+        util.errorLogger(error)
+        util.errorLogger("INDEX | Could not connect to server")
       })
     },
     async viewDisclaimer(destination: string) {

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -207,7 +207,13 @@ export default defineComponent({
       this.plotDirectory = config.plot.location
     },
     async waitNode() {
-      await this.$client.waitNodeStartApiConnect(this.plotDirectory)
+      const nodeName = (await appConfig.read()).nodeName
+      if (nodeName !== "") {
+        await this.$client.waitNodeStartApiConnect(this.plotDirectory, nodeName)
+      } else {
+        util.errorLogger("PLOTTING PROGRESS | node name was empty when tried to start node")
+      }
+
     },
     pausePlotting() {
       this.plotFinished = true

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -285,7 +285,7 @@ export default defineComponent({
       await appData.createCustomDataDir(this.plotDirectory)
       util.infoLogger("SETUP PLOT | custom directory created")
       await this.checkIdentity()
-      const nodeName = await this.client.generateNodeName()
+      const nodeName = util.generateNodeName()
       await appConfig.update({
           plot: { location: this.plotDirectory, sizeGB: this.allocatedGB },
           nodeName: nodeName

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -285,6 +285,12 @@ export default defineComponent({
       await appData.createCustomDataDir(this.plotDirectory)
       util.infoLogger("SETUP PLOT | custom directory created")
       await this.checkIdentity()
+      const nodeName = await this.client.generateNodeName()
+      await appConfig.update({
+          plot: { location: this.plotDirectory, sizeGB: this.allocatedGB },
+          nodeName: nodeName
+        })
+      this.$router.replace({ name: "plottingProgress" })
     },
     async updateDriveStats() {
       const stats = await native.driveStats(this.plotDirectory)
@@ -308,20 +314,17 @@ export default defineComponent({
       }
       else {
         util.infoLogger("SETUP PLOT | reward address was initialized before, proceeding to plotting")
-        await appConfig.update({
-          plot: { location: this.plotDirectory, sizeGB: this.allocatedGB },
-        })
-        this.$router.replace({ name: "plottingProgress" })
       }
     },
-    async viewMnemonic() {
-      const modal = await util.showModal(mnemonicModal)
-      modal?.onDismiss(async () => {
-        await appConfig.update({
-          plot: { location: this.plotDirectory, sizeGB: this.allocatedGB },
-          rewardAddress: this.rewardAddress
+    async viewMnemonic(): Promise<void> {
+      const modal = await util.showModal(mnemonicModal);
+      return new Promise((resolve) => {
+        modal?.onDismiss(async () => {
+          await appConfig.update({
+            rewardAddress: this.rewardAddress
+          })
+          resolve()
         })
-        this.$router.replace({ name: "plottingProgress" })
       })
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6192,6 +6192,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+random-word-slugs@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/random-word-slugs/-/random-word-slugs-0.1.6.tgz#1822f059e0e9a91e967a3eaed1e33580df0598cf"
+  integrity sha512-EVPGKyhXTdnBlMCrqBvby3nf9Jz+W/rVuP2nOi68aDZa6VJ2OXvz+VDCwl8jULBLZ1Ht8wscRA+/SogeI9NYGw==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
Fixes #197 

Also, refactors some frontend code such that the changed functions have more specific roles and they are better structured.

Lastly, `update` function for config was not `awaiting` on the `write` call to the filesystem. This was creating an edge case, where user closes the modal for viewing mnemonic (view mnemonic modal writes to config on dismiss). And after on dismiss, we are proceeding into `plottingProgress` page.
If the user closes the app immediately after proceeding into `plottingProgress` page, they will expect their reward address to be remembered. But the app sometimes may not have chance to write the `rewardAddress` to the config, since the write operation is not awaited on.
When the `write` operation is awaited, we will not proceed into `plottingProgress` page unless `rewardAddress` is correctly stored in config. 
Fixed also this 👍 

