### PR TITLE
bug fix and remove no longer needed plot progress tracker

### DIFF
--- a/src-tauri/src/farmer.rs
+++ b/src-tauri/src/farmer.rs
@@ -8,8 +8,6 @@ use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOption
 use subspace_farmer::{Identity, NodeRpcClient, ObjectMappings, Plot, RpcClient};
 use tokio::sync::mpsc::Sender;
 
-pub(crate) static PLOTTED_PIECES: AtomicUsize = AtomicUsize::new(0);
-
 /// Start farming by using plot in specified path and connecting to WebSocket server at specified
 /// address.
 pub(crate) async fn farm(
@@ -64,17 +62,6 @@ pub(crate) async fn farm(
         true,
     )
     .await?;
-
-    let plots = multi_farming.plots.clone();
-    let first_plot = plots.iter().next().unwrap();
-    first_plot
-        .on_progress_change(Arc::new(|plotted_pieces| {
-            PLOTTED_PIECES.fetch_add(
-                plotted_pieces.plotted_piece_count / PIECE_SIZE,
-                Ordering::SeqCst,
-            );
-        }))
-        .detach();
 
     tokio::spawn(async move {
         let result = multi_farming.wait().await;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,11 +41,6 @@ fn frontend_info_logger(message: &str) {
 }
 
 #[tauri::command]
-fn plot_progress_tracker() -> usize {
-    farmer::PLOTTED_PIECES.load(Ordering::Relaxed)
-}
-
-#[tauri::command]
 async fn farming(path: String, reward_address: String, plot_size: u64) -> bool {
     // create a channel to listen for farmer errors, and restart another farmer instance in case any error
     let (error_sender, mut error_receiver): (Sender<()>, Receiver<()>) = mpsc::channel(1);
@@ -161,7 +156,6 @@ async fn main() -> Result<()> {
                 get_disk_stats,
                 get_this_binary,
                 farming,
-                plot_progress_tracker,
                 start_node,
                 frontend_error_logger,
                 frontend_info_logger
@@ -174,7 +168,6 @@ async fn main() -> Result<()> {
                 get_this_binary,
                 get_disk_stats,
                 farming,
-                plot_progress_tracker,
                 start_node,
                 frontend_error_logger,
                 frontend_info_logger

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -189,7 +189,8 @@ export class Client {
 
   /* FARMER INTEGRATION */
   public async startFarming(path: string, plotSizeGB: number): Promise<boolean> {
-    const plotSize = Math.round(plotSizeGB * 1048576)
+    // convert GB to Bytes
+    const plotSize = Math.round(plotSizeGB * 1024 * 1024 * 1024)
     const rewardAddress: string = (await appConfig.read()).rewardAddress
     if (rewardAddress === "") {
       util.errorLogger("Tried to send empty reward address to backend!")


### PR DESCRIPTION
Probably some copy-pasta error, we changed the plot size back to 1024*1024 from 1024*1024*1024. 
Which was causing 20GB plot to effectively turn into 20MB plot.

Also, now that we changed how plottingProgress screen works, we don't need `plot_progress_tracker` function from backend. We don't use that information anymore. So I removed them (we can always get them back from git history if we need to)