### PR TITLE
node-restart mechanism

### DIFF
--- a/src-tauri/src/farmer.rs
+++ b/src-tauri/src/farmer.rs
@@ -6,6 +6,7 @@ use subspace_core_primitives::PublicKey;
 use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::{Identity, NodeRpcClient, ObjectMappings, Plot, RpcClient};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::time::{sleep, timeout, Duration};
 
 #[tauri::command]
 pub(crate) async fn farming(path: String, reward_address: String, plot_size: u64) -> bool {

--- a/src-tauri/src/farmer.rs
+++ b/src-tauri/src/farmer.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use subspace_core_primitives::PublicKey;
 use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::{Identity, NodeRpcClient, ObjectMappings, Plot, RpcClient};
-use tokio::net::tcp::TcpStream;
+use tokio::net::TcpStream;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::{sleep, timeout, Duration};
 
@@ -64,7 +64,7 @@ async fn farm(
 ) -> Result<(), anyhow::Error> {
     if let Err(error) = timeout(Duration::from_secs(20), async {
         loop {
-            if TcpStream::connect("127.0.0.1:9947").is_ok() {
+            if TcpStream::connect("127.0.0.1:9947").await.is_ok() {
                 break;
             } else {
                 sleep(Duration::from_millis(500)).await;

--- a/src-tauri/src/farmer.rs
+++ b/src-tauri/src/farmer.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow, Result};
 use log::{error, info};
-use std::net::TcpStream;
 use std::path::PathBuf;
 use subspace_core_primitives::PublicKey;
 use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::{Identity, NodeRpcClient, ObjectMappings, Plot, RpcClient};
+use tokio::net::tcp::TcpStream;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::{sleep, timeout, Duration};
 

--- a/src-tauri/src/node.rs
+++ b/src-tauri/src/node.rs
@@ -249,5 +249,3 @@ fn create_configuration<CS: ChainSpec + 'static>(
         force_new_slot_notifications: false,
     })
 }
-
-

--- a/src-tauri/src/node.rs
+++ b/src-tauri/src/node.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::Once;
 use subspace_runtime::GenesisConfig as ConsensusGenesisConfig;
 use subspace_service::{FullClient, NewFull, SubspaceConfiguration};
-use tokio::runtime::Handle;
+use tokio::{runtime::Handle, sync::Mutex, task::JoinHandle};
 
 static INITIALIZE_SUBSTRATE: Once = Once::new();
 
@@ -51,10 +51,10 @@ impl NativeExecutionDispatch for ExecutorDispatch {
 
 #[tauri::command]
 pub(crate) async fn start_node(path: String, node_name: String) {
-    init_node(path.into(), node_name).await.unwrap();
+    node_controller(path, node_name).await;
 }
 
-async fn init_node(base_directory: PathBuf, node_name: String) -> Result<()> {
+async fn init_node(base_directory: PathBuf, node_name: String) -> Result<JoinHandle<()>> {
     let chain_spec: ConsensusChainSpec<ConsensusGenesisConfig, ExecutionGenesisConfig> =
         ConsensusChainSpec::from_json_bytes(include_bytes!("../chain-spec.json").as_ref())
             .map_err(anyhow::Error::msg)?;
@@ -66,8 +66,7 @@ async fn init_node(base_directory: PathBuf, node_name: String) -> Result<()> {
 
     full_client.network_starter.start_network();
 
-    // TODO: Make this interruptable if needed
-    tokio::spawn(async move {
+    let node_handle = tokio::spawn(async move {
         if let Err(error) = full_client.task_manager.future().await {
             error!("Task manager exited with error: {error}");
         } else {
@@ -75,7 +74,7 @@ async fn init_node(base_directory: PathBuf, node_name: String) -> Result<()> {
         }
     });
 
-    Ok(())
+    Ok(node_handle)
 }
 
 // TODO: Allow customization of a bunch of these things
@@ -241,4 +240,16 @@ fn create_configuration<CS: ChainSpec + 'static>(
         },
         force_new_slot_notifications: false,
     })
+}
+
+// start a new node,
+// but if there is a node currently running, stops it as the first step
+pub(crate) async fn node_controller(path: String, node_name: String) {
+    static NODE_HANDLE: Mutex<Option<JoinHandle<()>>> = Mutex::const_new(None);
+
+    let mut node_handle_guard = NODE_HANDLE.lock().await;
+    if let Some(guard) = node_handle_guard.take() {
+        guard.abort();
+    }
+    *node_handle_guard = Some(init_node(path.into(), node_name).await.unwrap());
 }


### PR DESCRIPTION
It is draft, because we also have to introduce front-end changes. Before that, to eliminate redundant work, I wanted to get your recommendations on whether this approach makes sense to you @nazar-pc and @i1i1.

**Important:** This only includes a restart mechanism for node, not for farmer. I tried the same approach with farmer but could not succeed. Reasons are below. As a workaround, we were already listening for errors on the farmer, and if it crashes (and it will crash during a node restart), we were restarting the farmer. I just added some timeout between the restarts of farmer, giving some time to node to fully restart itself and start listening to farmer.

Reasons why I failed implementing a restart mechanism for farmer is:
- first problem:
    - we are waiting on the handle of the farmer job (which is the `MultiFarming` struct)
    - i also need to clone that handle, so if a `restart` request comes, i should drop this handle
    - this handle (`MultiFarming` struct) does not implement clone/copy, so I cannot have the same handle in two places. 
- second problem:
    - because of the already existing restart mechanism we have, the code becomes too ugly when I tried to implement the logic
    - so, even if we solve the first problem, I still argue against having a `stop` mechanism for farmer. I think our restart mechanism will do fine.