### PR TITLE
Refactoring client

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,6 +45,13 @@ async fn main() -> Result<()> {
         .init();
 
     let app = tauri::Builder::default()
+        .setup(|app| {
+            #[cfg(debug_assertions)] // only include this code on debug builds
+            {
+                app.get_window("main").unwrap().open_devtools();
+            }
+            Ok(())
+        })
         .menu(menu::get_menu())
         .system_tray(menu::get_tray_menu())
         .on_system_tray_event(|app, event| {

--- a/src/components/farmedList.vue
+++ b/src/components/farmedList.vue
@@ -53,7 +53,7 @@ q-card(bordered flat)
           .col-4
             p {{ formatAddress(block.rewardAddr) }}
           .col-3
-            a(:href="blockLink(block.blockNum.toString())" target="_blank") # {{ block.blockNum.toLocaleString() }}
+            a(:href="blockLink(block.blockNum)" target="_blank") # {{ block.blockNum.toLocaleString() }}
           .col-3
             p.text-weight-light {{ formatDate(block.time) }}
           .col-2
@@ -104,8 +104,8 @@ export default defineComponent({
     this.rewardAddress = (await appConfig.read()).rewardAddress;
   },
   methods: {
-    blockLink(blockNumber: string) {
-      return appsLink + blockNumber;
+    blockLink(blockNumber: number) {
+      return appsLink + blockNumber.toLocaleString();
     },
     formatDate(date: Date) {
       return formatDistanceToNowStrict(date)

--- a/src/components/farmedList.vue
+++ b/src/components/farmedList.vue
@@ -53,7 +53,7 @@ q-card(bordered flat)
           .col-4
             p {{ formatAddress(block.rewardAddr) }}
           .col-3
-            a(:href={{`${appsLink}${block.blockNum.toString()}`}} target="_blank") # {{ block.blockNum.toLocaleString() }}
+            a(:href="blockLink(block.blockNum.toString())" target="_blank") # {{ block.blockNum.toLocaleString() }}
           .col-3
             p.text-weight-light {{ formatDate(block.time) }}
           .col-2
@@ -98,12 +98,15 @@ export default defineComponent({
     },
     blocksListStyle(): { [index: string]: string } {
       return this.expanded ? { height: "370px" } : { height: "185px" }
-    }
+    },
   },
   async mounted() {
     this.rewardAddress = (await appConfig.read()).rewardAddress;
   },
   methods: {
+    blockLink(blockNumber: string) {
+      return appsLink + blockNumber;
+    },
     formatDate(date: Date) {
       return formatDistanceToNowStrict(date)
     },

--- a/src/components/farmedList.vue
+++ b/src/components/farmedList.vue
@@ -51,9 +51,9 @@ q-card(bordered flat)
         q-separator
         .row.q-pa-xs.q-ml-sm.q-ma-xs
           .col-4
-            p {{ block.rewardAddr.substring(0, 8) + '...' + block.rewardAddr.substring(block.rewardAddr.length - 8, block.rewardAddr.length) }}
+            p {{ formatAddress(block.rewardAddr) }}
           .col-3
-            a(:href="block.appsLink" target="_blank") # {{ block.blockNum.toLocaleString() }}
+            a(:href={{`${appsLink}${block.blockNum.toString()}`}} target="_blank") # {{ block.blockNum.toLocaleString() }}
           .col-3
             p.text-weight-light {{ formatDate(block.time) }}
           .col-2
@@ -63,12 +63,16 @@ q-card(bordered flat)
 <script lang="ts">
 import { defineComponent } from "vue"
 import { formatDistanceToNowStrict } from "date-fns"
+import * as process from "process"
 import * as util from "../lib/util"
 import { globalState as global } from "../lib/global"
 import { FarmedBlock } from "../lib/types"
 import { appConfig } from "../lib/appConfig"
 
 const lang = global.data.loc.text.dashboard
+
+const NETWORK_RPC = process.env.PUBLIC_API_WS || "ws://localhost:9947";
+const appsLink = "https://polkadot.js.org/apps/?rpc=" + NETWORK_RPC + "#/explorer/query/"
 
 export default defineComponent({
   props: {
@@ -77,10 +81,13 @@ export default defineComponent({
   },
   emits: ["expand"],
   data() {
-    return { lang, util, global: global.data, rewardAddress: "", }
-  },
-  async mounted() {
-    this.rewardAddress = await this.displayRewardAddress()
+    return { 
+      lang, 
+      util, 
+      global: global.data, 
+      rewardAddress: "", 
+      appsLink,
+    }
   },
   computed: {
     farmedBlocksList(): FarmedBlock[] {
@@ -93,18 +100,15 @@ export default defineComponent({
       return this.expanded ? { height: "370px" } : { height: "185px" }
     }
   },
+  async mounted() {
+    this.rewardAddress = (await appConfig.read()).rewardAddress;
+  },
   methods: {
     formatDate(date: Date) {
       return formatDistanceToNowStrict(date)
     },
-    async displayRewardAddress() {
-      const rewardAddress = (await appConfig.read()).rewardAddress
-      if (rewardAddress === "") {
-        util.errorLogger("Reward Address was null/undefined!")
-        return "???"
-      } else {
-        return rewardAddress
-      }
+    formatAddress(address: string){
+      return address.substring(0, 8) + '...' + address.substring(address.length - 8, address.length)
     }
   }
 })

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -19,9 +19,6 @@ import { IU8a } from "@polkadot/types-codec/types"
 const tauri = { event, invoke }
 const SUNIT = 1000000000000000000n
 
-const NETWORK_RPC = process.env.PUBLIC_API_WS || "ws://localhost:9947";
-const appsLink = "https://polkadot.js.org/apps/?rpc=" + NETWORK_RPC + "#/explorer/query/"
-
 export class Client {
   protected firstLoad = false
   protected mnemonic = ""
@@ -82,11 +79,8 @@ export class Client {
             feeReward: 0,
             // TODO: check if necessary to store address here since we only process blocks farmed by user
             rewardAddr: rewardAddress.toString(),
-            appsLink: appsLink + blockNum.toString()
           }
-          this.data.farming.farmed = [block].concat(
-            this.data.farming.farmed
-          )
+          this.data.farming.farmed = [block, ...this.data.farming.farmed];
           storeBlocks(this.data.farming.farmed)
           this.data.farming.events.emit("farmedBlock", block)
 
@@ -95,7 +89,6 @@ export class Client {
       }
     )
 
-    // TODO: move to separate method
     process.on("beforeExit", this.stopSubscription)
     window.addEventListener("unload", this.stopSubscription)
     this.clearTauriDestroy = await tauri.event.once(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -11,7 +11,6 @@ import { appConfig } from "./appConfig"
 import { getStoredBlocks, storeBlocks } from "./blockStorage"
 import {
   emptyClientData,
-  NetStatus,
   FarmedBlock,
   SubPreDigest
 } from "../lib/types"
@@ -32,16 +31,14 @@ export class Client {
 
   private api: ApiPromise;
 
-  constructor (api: ApiPromise) {
+  constructor(api: ApiPromise) {
     this.api = api;
   }
 
   data = reactive(emptyClientData)
-  status = {
-    net: async (): Promise<NetStatus> => {
-      const peers = await this.api.rpc.system.peers()
-      return { peers }
-    }
+  async getPeersCount(): Promise<number> {
+    const peers = await this.api.rpc.system.peers();
+    return peers.length;
   }
   do = {
     blockSubscription: {
@@ -154,7 +151,7 @@ export class Client {
     await this.api.isReadyOrError
   }
 
-  public async getSyncState():Promise<SyncState> {
+  public async getSyncState(): Promise<SyncState> {
     return this.api.rpc.system.syncState();
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,7 +11,6 @@ export interface FarmedBlock {
   feeReward: number
   id: string
   rewardAddr: string
-  appsLink: string
 }
 
 export interface AutoLaunchParams {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,3 @@
-import { Vec } from "@polkadot/types/codec"
-import { PeerInfo } from "@polkadot/types/interfaces/system"
 import mitt, { Emitter } from "mitt"
 import { ApexOptions } from "apexcharts"
 import type { AccountId32 } from "@polkadot/types/interfaces"
@@ -25,10 +23,6 @@ export interface AutoLaunchParams {
 export interface ChildReturnData {
   stdout: string[]
   stderr: string[]
-}
-
-export interface NetStatus {
-  peers: Vec<PeerInfo>
 }
 
 export interface PeerData {

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -111,7 +111,7 @@ export default defineComponent({
   unmounted() {
     this.unsubscribe()
     clearInterval(this.peerInterval)
-    this.$client.do.blockSubscription.stop()
+    this.$client.stopSubscription()
     this.$client.data.farming.events.off("newBlock", this.newBlock)
     this.$client.data.farming.events.off("farmedBlock", this.farmBlock)
   },

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -97,7 +97,10 @@ export default defineComponent({
 
     this.clientData = this.$client.data
     this.loading = false
-    this.peerInterval = window.setInterval(this.getNetInfo, 10000)
+
+    this.fetchPeersCount();// fetch initial peers count value
+    this.peerInterval = window.setInterval(this.fetchPeersCount, 30000);
+    
     this.$client.data.farming.events.on("newBlock", this.newBlock)
     this.$client.data.farming.events.on("farmedBlock", this.farmBlock)
     this.global.status.state = "live"
@@ -113,9 +116,9 @@ export default defineComponent({
     this.$client.data.farming.events.off("farmedBlock", this.farmBlock)
   },
   methods: {
-    async getNetInfo() {
-      const netData = await this.$client.status.net()
-      this.network.peers = netData.peers.length
+    async fetchPeersCount() {
+      const peers = await this.$client.getPeersCount();
+      this.network.peers = peers;
     },
     expand(val: boolean) {
       this.expanded = val

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -89,7 +89,7 @@ export default defineComponent({
         util.errorLogger("DASHBOARD | Farmer start error!")
       }
       util.infoLogger("DASHBOARD | starting block subscription")
-      await this.$client.startBlockSubscription()
+      await this.$client.startSubscription();
     }
 
     this.global.status.state = "loading"

--- a/src/pages/PlottingProgress.vue
+++ b/src/pages/PlottingProgress.vue
@@ -221,7 +221,7 @@ export default defineComponent({
       }
       util.infoLogger("PLOTTING PROGRESS | farmer started")
       this.plottingData.allocatedGB = config.plot.sizeGB
-      await this.$client.startBlockSubscription()
+      await this.$client.startSubscription();
       util.infoLogger("PLOTTING PROGRESS | block subscription started")
       this.syncState = (await this.$client.getSyncState()).toJSON() as unknown as SyncState;
 


### PR DESCRIPTION
- `Client` module refactoring
- move polkadot/apps link from client to `farmedList` component (since it belongs to presentation logic)
- fetch initial peers count value when Dashboard mounts and increase timeout for refetching
- other minor improvements