### PR TITLE
fix version

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-desktop"
-version = "0.6.1"
+version = "0.6.2"
 description = "Subspace desktop"
 authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
missed Subspace Desktop version in cargo.toml