### PR TITLE
Reset and log extraction

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -88,7 +88,8 @@ async fn main() -> Result<()> {
                 farmer::farming,
                 node::start_node,
                 utils::frontend_error_logger,
-                utils::frontend_info_logger
+                utils::frontend_info_logger,
+                utils::custom_log_dir
             ],
             #[cfg(target_os = "windows")]
             tauri::generate_handler![
@@ -100,7 +101,8 @@ async fn main() -> Result<()> {
                 farmer::farming,
                 node::start_node,
                 utils::frontend_error_logger,
-                utils::frontend_info_logger
+                utils::frontend_info_logger,
+                utils::custom_log_dir
             ],
         )
         .build(ctx)

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -63,6 +63,7 @@ pub(crate) fn frontend_info_logger(message: &str) {
     info!("Frontend info: {message}");
 }
 
+#[tauri::command]
 pub(crate) fn custom_log_dir(id: &str) -> PathBuf {
     #[cfg(target_os = "macos")]
     let path = dirs::home_dir().map(|dir| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,7 +55,7 @@
       "shell": {
         "all": true,
         "execute": true,
-        "open": true,
+        "open": "[/subspace\\-desktop/]",
         "scope": [
           {
             "name": "run-osascript",

--- a/src/components/SaveKeys.vue
+++ b/src/components/SaveKeys.vue
@@ -34,7 +34,7 @@
               style="max-width: 200px"
             )
     .row
-      p Seed phrases are your password for your subspace farmer and wallet, this cannot be changed, guessed(easily), or reset if lost. It is imperative that this is stored in a secure, safe location. Without the seed phrase, you will not have access to your funds. Furthermore, anyone who steals your seed phrase will be able to do as they please with your funds.
+      p Seed phrase is your password for your subspace farmer and wallet, this cannot be changed, guessed, or reset if lost. It is imperative that this is stored in a secure, safe location. Without the seed phrase, you will not have access to your funds. Furthermore, anyone who steals your seed phrase will be able to do as they please with your funds.
   .row.q-pt-md
     q-checkbox(:label="lang.userConfirm" size="lg" v-model="userConfirm" :disable="!revealKey")
 </template>

--- a/src/components/SaveKeys.vue
+++ b/src/components/SaveKeys.vue
@@ -3,7 +3,7 @@
   .row.justify-center.q-gutter-lg
     .col-auto
       q-icon(color="blue-3" name="vpn_key" size="80px")
-      p.q-ml-sm {{ lang.privateKey }}
+      p.q-ml-sm {{ lang.seedPhrase }}
     .col
       .row.justify-center
         .col-8
@@ -34,7 +34,7 @@
               style="max-width: 200px"
             )
     .row
-      p Private keys are your password for your subspace farmer and wallet, this cannot be changed, guessed(easily), or reset if lost. It is imperative that this is stored in a secure, safe location. Without the Private Key you will not have access to your funds. Furthermore, anyone who steals your private keys will be able to do as they please with your funds.
+      p Seed phrases are your password for your subspace farmer and wallet, this cannot be changed, guessed(easily), or reset if lost. It is imperative that this is stored in a secure, safe location. Without the seed phrase, you will not have access to your funds. Furthermore, anyone who steals your seed phrase will be able to do as they please with your funds.
   .row.q-pt-md
     q-checkbox(:label="lang.userConfirm" size="lg" v-model="userConfirm" :disable="!revealKey")
 </template>

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -12,6 +12,12 @@ q-menu(auto-close)
         .col
           p.text-grey(v-if="!launchOnStart") {{ lang.autoStart }}
           p.text-black(v-else) {{ lang.autoStart }}
+    q-item(@click="exportLogs()" clickable)
+      .row.items-center
+        .col-auto.q-mr-md
+          q-icon(name="print")
+        .col
+          p {{ lang.export_log }}
     q-item(@click="reset()" clickable)
       .row.items-center
         .col-auto.q-mr-md
@@ -26,8 +32,10 @@ import { Dialog, Notify } from "quasar"
 import { relaunch } from "@tauri-apps/api/process"
 import * as util from "../lib/util"
 import { globalState as global } from "../lib/global"
+import { open as shell_open } from '@tauri-apps/api/shell'
 
 const lang = global.data.loc.text.mainMenu
+
 
 export default defineComponent({
   data() {
@@ -92,6 +100,15 @@ export default defineComponent({
         await new Promise((resolve) => setTimeout(resolve, 1000))
         await relaunch()
       })
+    },
+    async exportLogs() {
+      try {
+        const log_path = await util.getLogPath()
+        console.log("THIS IS LOG PATH:", log_path)
+        await shell_open(log_path)
+      } catch(error) {
+        console.error(error)
+      }
     },
     async initMenu() {
       if (this.$autoLauncher.enabled !== undefined) {

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -12,7 +12,7 @@ q-menu(auto-close)
         .col
           p.text-grey(v-if="!launchOnStart") {{ lang.autoStart }}
           p.text-black(v-else) {{ lang.autoStart }}
-    q-item(@click="reset()" clickable v-if="util.CONTEXT_MENU != 'OFF'")
+    q-item(@click="reset()" clickable)
       .row.items-center
         .col-auto.q-mr-md
           q-icon(color="red" name="refresh")
@@ -22,7 +22,7 @@ q-menu(auto-close)
 
 <script lang="ts">
 import { defineComponent } from "vue"
-import { Dialog, LocalStorage, Notify } from "quasar"
+import { Dialog, Notify } from "quasar"
 import { relaunch } from "@tauri-apps/api/process"
 import * as util from "../lib/util"
 import { globalState as global } from "../lib/global"
@@ -76,12 +76,12 @@ export default defineComponent({
       Dialog.create({
         message: `
         <h6>
-          Are you sure you want to reset?
+          ${lang.reset_heading}
         </h6>
         <div style="height:10px;">
         </div>
         <p>
-          You will need to re-import your existing private key in order to recover any existing plot or funds.
+         ${lang.reset_explanation}
         </p>
         `,
         html: true,

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -32,7 +32,7 @@ import { Dialog, Notify } from "quasar"
 import { relaunch } from "@tauri-apps/api/process"
 import * as util from "../lib/util"
 import { globalState as global } from "../lib/global"
-import { open as shell_open } from '@tauri-apps/api/shell'
+import { open as shellOpen } from '@tauri-apps/api/shell'
 
 const lang = global.data.loc.text.mainMenu
 
@@ -105,7 +105,7 @@ export default defineComponent({
       try {
         const log_path = await util.getLogPath()
         console.log("THIS IS LOG PATH:", log_path)
-        await shell_open(log_path)
+        await shellOpen(log_path)
       } catch(error) {
         console.error(error)
       }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -31,6 +31,10 @@ export async function showModal(
   })
 }
 
+export async function getLogPath(): Promise<string> {
+  return await invoke("custom_log_dir", { id: appName })
+}
+
 export async function errorLogger(error: unknown): Promise<void> {
   if (error instanceof Error) {
     const message = error.message

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -81,9 +81,11 @@
   "mainMenu": {
     "IncentivizedLabel": "Incentivized Testnet",
     "IncentivizedTooltip": "Rewards (testSSC) you earn during incentivized testnet, will contribute to your mainnet rewards!",
-    "reset": "Reset",
+    "reset": "Reset Node!",
     "autoStart": "Start on Boot",
     "willAutoLaunch": "Subspace will launch automatically during boot",
-    "willNotAutoLaunch": "Subspace will not launch automatically during boot"
+    "willNotAutoLaunch": "Subspace will not launch automatically during boot",
+    "reset_heading": "Are you sure you want to reset and start from scratch?",
+    "reset_explanation": " This will erase everything, and you will have to start from the beginning. Only do this if there is something wrong in the network, or you imported a wrong reward address. You will need to re-import your existing private key."
   }
 }

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -86,7 +86,7 @@
     "willAutoLaunch": "Subspace will launch automatically during boot",
     "willNotAutoLaunch": "Subspace will not launch automatically during boot",
     "reset_heading": "Are you sure you want to reset and start from scratch?",
-    "reset_explanation": " This will erase everything, and you will have to start from the beginning. Only do this if there is something wrong in the network, or you imported a wrong reward address.",
+    "reset_explanation": " This will erase everything, and you will have to start from the beginning. Only do this if there is something wrong with the network, or you imported a wrong reward address.",
     "export_log": "Show Logs"
   }
 }

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -6,12 +6,12 @@
     "advanced": "I've run a farmer before and still have my keys"
   },
   "saveKeys": {
-    "pageTitle": "Backup Private Key",
-    "tooltip": "Please confirm you have backed up your private key first",
-    "yourPrivateKey": "Your private key",
-    "userConfirm": "I have backed up my private key. I understand that my account can't be recovered without my private key.",
-    "saved": "Private Key copied to clipboard. Backup key in a secure location.",
-    "privateKey": "Private Key",
+    "pageTitle": "Backup Seed Phrase",
+    "tooltip": "Please confirm you have backed up your seed phrase first",
+    "yourSeedPhrase": "Your seed phrase",
+    "userConfirm": "I have backed up my seed phrase. I understand that my account can't be recovered without my seed phrase.",
+    "saved": "Seed phrase copied to clipboard. Backup key in a secure location.",
+    "seedPhrase": "Seed phrase",
     "reveal": "reveal",
     "copy": "copy to clipboard"
   },
@@ -86,7 +86,7 @@
     "willAutoLaunch": "Subspace will launch automatically during boot",
     "willNotAutoLaunch": "Subspace will not launch automatically during boot",
     "reset_heading": "Are you sure you want to reset and start from scratch?",
-    "reset_explanation": " This will erase everything, and you will have to start from the beginning. Only do this if there is something wrong in the network, or you imported a wrong reward address. You will need to re-import your existing private key.",
+    "reset_explanation": " This will erase everything, and you will have to start from the beginning. Only do this if there is something wrong in the network, or you imported a wrong reward address.",
     "export_log": "Show Logs"
   }
 }

--- a/src/loc/en.json
+++ b/src/loc/en.json
@@ -86,6 +86,7 @@
     "willAutoLaunch": "Subspace will launch automatically during boot",
     "willNotAutoLaunch": "Subspace will not launch automatically during boot",
     "reset_heading": "Are you sure you want to reset and start from scratch?",
-    "reset_explanation": " This will erase everything, and you will have to start from the beginning. Only do this if there is something wrong in the network, or you imported a wrong reward address. You will need to re-import your existing private key."
+    "reset_explanation": " This will erase everything, and you will have to start from the beginning. Only do this if there is something wrong in the network, or you imported a wrong reward address. You will need to re-import your existing private key.",
+    "export_log": "Show Logs"
   }
 }


### PR DESCRIPTION
Code-wise -> trivial. 
But it will be wordy to explain the changes.

- 1st change: `reset` button re-added. But changed the wording significantly. Please read the new messages. Any recommendation is welcome
- 2nd change: another button for viewing the logs.
    - viewing, not exporting, since I did not want to make the UI cumbersome and pop up many dialogs for where to save the log file, getting permissions and etc. So, as a workaround, when you click `view logs`, it will open the file location of the log file, using the native file explorer for the OS.
    - to be able to view the log file, we needed the path to it. I'm not hardcoding the path, but getting it from tauri. 
    - we are using tauri's `shell` api to be able to use the native file explorer. And that needs a weird check in the `tauri.conf.json`. It needs a regex that should match against the provided path. Or else, it does not run the command. That's why I supplied regex of including the string of `subspace-desktop`.
- 3rd change: `private key` names are changed with `seed phrase`, since we decided on following a terminology, and we should be consistent. 


That's all, thanks for reading :D