### PR TITLE
Editable node name

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "cirrus-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "cirrus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "cirrus-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "cirrus-pallet-executive",
  "cirrus-primitives",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5115,7 +5115,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5131,7 +5131,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5197,7 +5197,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5210,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6695,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6735,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -7180,7 +7180,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8138,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "sp-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8253,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -8698,7 +8698,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "merkle_light",
  "parity-scale-codec",
@@ -8712,7 +8712,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "hmac 0.12.1",
  "num-traits",
@@ -8763,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.3.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8826,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "bytes",
  "event-listener-primitives",
@@ -8844,7 +8844,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "hex-buffer-serde",
  "serde",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "cirrus-primitives",
  "cirrus-runtime",
@@ -8902,7 +8902,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -8916,7 +8916,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "cirrus-primitives",
  "derive_more",
@@ -8965,7 +8965,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 dependencies = [
  "merlin",
  "num-traits",
@@ -8982,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=17e72ba61f9ee62b3df357dc03196330dd134285#17e72ba61f9ee62b3df357dc03196330dd134285"
+source = "git+https://github.com/subspace/subspace?rev=eaff7053cb36fbf93fa43c1b19900a5b26037916#eaff7053cb36fbf93fa43c1b19900a5b26037916"
 
 [[package]]
 name = "substrate-bip39"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ tauri-build = { version = "1.0.0-rc.9", features = [] }
 
 [dependencies]
 anyhow = "1.0.44"
-cirrus-runtime = { git = "https://github.com/subspace/subspace", rev = "17e72ba61f9ee62b3df357dc03196330dd134285" }
+cirrus-runtime = { git = "https://github.com/subspace/subspace", rev = "eaff7053cb36fbf93fa43c1b19900a5b26037916" }
 dirs = "4.0.0"
 dotenv = "0.15.0"
 event-listener-primitives = "2.0.1"
@@ -25,16 +25,16 @@ sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/subs
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22", features = ["wasmtime"] }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22", features = ["wasmtime"] }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "17e72ba61f9ee62b3df357dc03196330dd134285" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "eaff7053cb36fbf93fa43c1b19900a5b26037916" }
 serde_json = "1.0.81"
 serde = { version = "1.0.137", features = [ "derive" ] }
 sp-core = { version = "6.0.0", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
 sp-panic-handler = { version = "4.0.0", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "17e72ba61f9ee62b3df357dc03196330dd134285" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "17e72ba61f9ee62b3df357dc03196330dd134285" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "17e72ba61f9ee62b3df357dc03196330dd134285" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "17e72ba61f9ee62b3df357dc03196330dd134285" }
-subspace-solving = { git = "https://github.com/subspace/subspace", rev = "17e72ba61f9ee62b3df357dc03196330dd134285" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "eaff7053cb36fbf93fa43c1b19900a5b26037916" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "eaff7053cb36fbf93fa43c1b19900a5b26037916" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "eaff7053cb36fbf93fa43c1b19900a5b26037916" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "eaff7053cb36fbf93fa43c1b19900a5b26037916" }
+subspace-solving = { git = "https://github.com/subspace/subspace", rev = "eaff7053cb36fbf93fa43c1b19900a5b26037916" }
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.31"
 tracing-subscriber = "0.3.11"

--- a/src-tauri/src/farmer.rs
+++ b/src-tauri/src/farmer.rs
@@ -1,12 +1,10 @@
 use anyhow::{anyhow, Result};
-use log::{error, info};
+use log::info;
 use std::path::PathBuf;
 use subspace_core_primitives::PublicKey;
 use subspace_farmer::multi_farming::{MultiFarming, Options as MultiFarmingOptions};
 use subspace_farmer::{Identity, NodeRpcClient, ObjectMappings, Plot, RpcClient};
-use tokio::net::TcpStream;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::time::{sleep, timeout, Duration};
 
 #[tauri::command]
 pub(crate) async fn farming(path: String, reward_address: String, plot_size: u64) -> bool {
@@ -62,20 +60,6 @@ async fn farm(
     plot_size: u64,
     error_sender: Sender<()>,
 ) -> Result<(), anyhow::Error> {
-    if let Err(error) = timeout(Duration::from_secs(20), async {
-        loop {
-            if TcpStream::connect("127.0.0.1:9947").await.is_ok() {
-                break;
-            } else {
-                sleep(Duration::from_millis(500)).await;
-            }
-        }
-    })
-    .await
-    {
-        error!("Node is not responding for 20 seconds, farmer is unable to start");
-        return Err(anyhow!(error));
-    }
     raise_fd_limit();
 
     let reward_address = if let Some(reward_address) = reward_address {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -95,12 +95,11 @@ export default defineComponent({
       // if user left input empty - use prev name
       if (!global.data.nodeName) {
         global.setNodeName(this.oldNodeName)
-      } else {
-        global.setNodeName(global.data.nodeName)
-        await appConfig.update({ nodeName: global.data.nodeName })
-        // TODO: consider restarting elsewhere
-        console.log('Restarting...');
-        await relaunch()
+      // only restart if name has changed
+      } else if (this.oldNodeName !== global.data.nodeName) {
+        await appConfig.update({ nodeName: global.data.nodeName });
+        global.setNodeName(global.data.nodeName);
+        await relaunch();
       }
     },
     setEditName(value: boolean) {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -14,9 +14,9 @@ q-layout(view="hHh lpr fFf")
               .col
                 p.no-margin(style="font-size: 12px") {{ lang.IncentivizedTooltip }}
           .col-auto.q-mr-md.relative-position(v-if="global.nodeName || oldNodeName")
-            // TODO: add .cursor-pointer and @click="onNameClick" after node restarting is implemented on the backend
-            q-badge(
+            q-badge.cursor-pointer(
               v-if="!isEdittingName"
+              @click="onNameClick"
               color="blue-8"
               text-color="white"
             )
@@ -54,6 +54,7 @@ import * as util from "../lib/util"
 import MainMenu from "../components/mainMenu.vue"
 import { globalState as global } from "../lib/global"
 import { appConfig } from "../lib/appConfig"
+import { relaunch } from "@tauri-apps/api/process"
 
 const lang = global.data.loc.text.mainMenu
 
@@ -90,15 +91,17 @@ export default defineComponent({
       this.oldNodeName = global.data.nodeName;
     },
     async saveName() {
+      this.setEditName(false);
       // if user left input empty - use prev name
       if (!global.data.nodeName) {
         global.setNodeName(this.oldNodeName)
       } else {
         global.setNodeName(global.data.nodeName)
         await appConfig.update({ nodeName: global.data.nodeName })
+        // TODO: consider restarting elsewhere
+        console.log('Restarting...');
+        await relaunch()
       }
-
-      this.setEditName(false);
     },
     setEditName(value: boolean) {
       this.isEdittingName = value;


### PR DESCRIPTION
Temporary solution for editable node name. 

This PR:
1- reverts the `node-restart` PR, since we have a bug about it (details below)
2- as a workaround, when `node_name` is edited, it calls the `relaunch()` function from tauri. This seems to work on linux and macos. Needs to be tested in windows though.
3- updates the monorepo dependencies as well as Nazar requested.

### Bug about the `node-restart` PR 
When node is restarted, the whole application crashes with the error `database file is in use`. This is related to node, not farmer. I debugged it yesterday, and it went deep to `sc_service` crate. Will continue debugging today. 
I suspected it was due to `abort` operation on the `handle` is not completed till we initiate the next instance of node. However, I don't think that is the case. There are 2 reasons:
1- i put 10 seconds of sleep after abort, error persists
2- i updated `tokio`, and used `is_finished()` function on the handle, in a loop, before starting the next node instance, which checks the job is cancelled or not, and is suggested to use after `abort`. Again, the issue persists.

So, instead of updating the dependencies and release a buggy version, I reverted the changes temporarily. `relaunch()` seems to do the job. But for the long-term, debugging the issue we have with `node-restart` may be useful. So I'm planning to keep working on debugging it.