### PR TITLE
232 inconsistent UI when manually setting allocated in setup plots

### DIFF
--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -55,6 +55,8 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
                 q-tooltip.q-pa-sm
                   p {{ lang.availableSpace }}
               .q-mt-sm {{ lang.allocated }}
+              // TODO: get error message from internationalization context
+              // TODO: remove validation and restrict input to positive numbers when possible (Quasar component limitation)
               q-input(
                 type="number"
                 bg-color="blue-2"
@@ -184,6 +186,7 @@ export default defineComponent({
       }
     },
     allocatedGB(val) {
+      // input component currently allows negative numbers as value, so we need to check
       if (val >= 0) {
         if (!this.stats?.safeAvailableGB) return
         if (val > this.stats?.safeAvailableGB) {

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -56,12 +56,14 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
                   p {{ lang.availableSpace }}
               .q-mt-sm {{ lang.allocated }}
               q-input(
+                type="number"
                 bg-color="blue-2"
                 dense
                 input-class="setupPlotInput"
                 outlined
                 suffix="GB"
-                v-model="allocatedGB"
+                v-model.number="allocatedGB"
+                :rules="[val => val > 0 || 'Value should be a positive number']"
               )
                 q-tooltip.q-pa-sm
                   p {{ lang.allocatedSpace }}
@@ -97,7 +99,7 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
     .col-expand
     .col-auto
       q-btn(
-        :disable="!validPath"
+        :disable="(!validPath || allocatedGB <= 0)"
         @click="confirmCreateDir()"
         color="blue-8"
         icon-right="downloading"
@@ -144,7 +146,7 @@ export default defineComponent({
       return [
         this.stats.utilizedGB,
         this.stats.freeGB,
-        this.allocatedGB < 5 ? 5 : this.allocatedGB
+        this.allocatedGB,
       ]
     },
     stats(): StatsType {
@@ -182,15 +184,19 @@ export default defineComponent({
       }
     },
     allocatedGB(val) {
-      if (!this.stats?.safeAvailableGB) return
-      if (val > this.stats?.safeAvailableGB) {
-        this.$nextTick(() => {
-          this.allocatedGB = parseFloat(this.stats?.safeAvailableGB.toFixed(0))
-        })
+      if (val >= 0) {
+        if (!this.stats?.safeAvailableGB) return
+        if (val > this.stats?.safeAvailableGB) {
+          this.$nextTick(() => {
+            this.allocatedGB = parseFloat(this.stats?.safeAvailableGB.toFixed(0))
+          })
+        } else {
+          this.$nextTick(() => {
+            this.allocatedGB = util.toFixed(this.allocatedGB, 2)
+          })
+        }
       } else {
-        this.$nextTick(() => {
-          this.allocatedGB = util.toFixed(this.allocatedGB, 2)
-        })
+        this.allocatedGB = 0;
       }
     }
   },


### PR DESCRIPTION
Fix for #232 

Unfortunately Quasar input component does not allow explicit input change events handling (it encourages using `v-model` instead), so we cannot restrict users from entering negative numbers, to mitigate this I have added input validation, error message, and disable button to proceed if the input value is not a positive number. Added TODO comment to fix this when possible.