### PR TITLE
updated dependencies and bumped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-desktop",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "description": "Subspace desktop",
   "author": "Subspace Labs <https://subspace.network>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "cirrus-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "cirrus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -958,7 +958,7 @@ dependencies = [
 [[package]]
 name = "cirrus-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "cirrus-pallet-executive",
  "cirrus-primitives",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5115,7 +5115,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5131,7 +5131,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5197,7 +5197,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5210,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6670,7 +6670,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6710,7 +6710,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6750,7 +6750,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -7195,7 +7195,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8153,7 +8153,7 @@ dependencies = [
 [[package]]
 name = "sp-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8268,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -8713,7 +8713,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "merkle_light",
  "parity-scale-codec",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "hmac 0.12.1",
  "num-traits",
@@ -8740,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-desktop"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "cirrus-runtime",
@@ -8780,7 +8780,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.3.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8824,7 +8824,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "bytes",
  "event-listener-primitives",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "hex-buffer-serde",
  "serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "cirrus-primitives",
  "cirrus-runtime",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -8932,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "cirrus-primitives",
  "derive_more",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 dependencies = [
  "merlin",
  "num-traits",
@@ -9002,7 +9002,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=00670c9714949ec8f776e7f0467110945866457b#00670c9714949ec8f776e7f0467110945866457b"
+source = "git+https://github.com/subspace/subspace?rev=3c3a48f865cfe0a2510512bc75e4bae099e27aae#3c3a48f865cfe0a2510512bc75e4bae099e27aae"
 
 [[package]]
 name = "substrate-bip39"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-desktop"
-version = "0.6.6"
+version = "0.6.7"
 description = "Subspace desktop"
 authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ tauri-build = { version = "1.0.0-rc.9", features = [] }
 
 [dependencies]
 anyhow = "1.0.44"
-cirrus-runtime = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
+cirrus-runtime = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
 dirs = "4.0.0"
 dotenv = "0.15.0"
 event-listener-primitives = "2.0.1"
@@ -26,17 +26,17 @@ sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/subs
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22", features = ["wasmtime"] }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22", features = ["wasmtime"] }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
 serde_json = "1.0.81"
 serde = { version = "1.0.137", features = [ "derive" ] }
 sp-core = { version = "6.0.0", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
 sp-panic-handler = { version = "4.0.0", git = "https://github.com/subspace/substrate", rev = "5f0aa1feb7250ac7b8c1b9928f87b2420b530e22" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
-subspace-solving = { git = "https://github.com/subspace/subspace", rev = "00670c9714949ec8f776e7f0467110945866457b" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
+subspace-solving = { git = "https://github.com/subspace/subspace", rev = "3c3a48f865cfe0a2510512bc75e4bae099e27aae" }
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.31"
 tracing-subscriber = "0.3.11"

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -104,10 +104,10 @@ export default defineComponent({
     async exportLogs() {
       try {
         const log_path = await util.getLogPath()
-        console.log("THIS IS LOG PATH:", log_path)
+        util.infoLogger("log path acquired:" + log_path)
         await shellOpen(log_path)
       } catch(error) {
-        console.error(error)
+        util.errorLogger(error)
       }
     },
     async initMenu() {


### PR DESCRIPTION
also made `show logs` button related logging directed into our logger, instead of the console