### PR TITLE
show block height when synced as well

### DIFF
--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -100,7 +100,7 @@ export default defineComponent({
 
     this.fetchPeersCount();// fetch initial peers count value
     this.peerInterval = window.setInterval(this.fetchPeersCount, 30000);
-    
+
     this.$client.data.farming.events.on("newBlock", this.newBlock)
     this.$client.data.farming.events.on("farmedBlock", this.farmBlock)
     this.global.status.state = "live"
@@ -144,7 +144,7 @@ export default defineComponent({
         syncState = await this.$client.getSyncState()
       } while (syncState.currentBlock.toNumber() < syncState.highestBlock.unwrapOrDefault().toNumber())
 
-      this.network.message = lang.synced
+      this.network.message = `Node is synced at block: ${syncState.currentBlock}`
       this.network.state = "finished"
     },
     newBlock(blockNumber: number) {


### PR DESCRIPTION
After a few complaints, we decided to show the block height again when the node is synced. 

Here how it looks:
![image](https://user-images.githubusercontent.com/32795992/173910042-a4eb0bb4-b5c2-4741-b91e-f1ef1b9a9f04.png)

I checked on `dev chain`, and it was updating the block heigh value as expected. 
Please check the wording, it may be improved :)