### PR TITLE
resizable + minimum dimension limit

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,9 +68,11 @@
     "windows": [
       {
         "title": "Subspace Desktop",
+        "minWidth": 800,
+        "minHeight": 600,
         "width": 800,
         "height": 600,
-        "resizable": false,
+        "resizable": true,
         "fullscreen": false
       }
     ],


### PR DESCRIPTION
Now, the users will be able to resize the application. 

The UI breaks when the dimensions are smaller than `800x600`. So I put some extra limits on that, and the app dimension can't go lower now.

The UI can definitely be optimized for large screens, but at least it does not break, and it can be an optimization for the future. 
