### PR TITLE
fix openssl and update allowlist - version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace-desktop",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "private": true,
   "description": "Subspace desktop",
   "author": "Subspace Labs <https://subspace.network>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8696,7 +8696,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-desktop"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "cirrus-runtime",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -383,24 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
-name = "attohttpc"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262c3f7f5d61249d8c00e5546e2685cd15ebeeb1bc0f3cc5449350a1cb07319e"
-dependencies = [
- "flate2",
- "http",
- "log",
- "native-tls",
- "openssl",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "url",
- "wildmatch",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4640,24 +4622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,37 +4997,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "orml-vesting"
@@ -7625,18 +7562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa 1.0.1",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_with"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9270,7 +9195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c7350af2191f3b7a288cadd672a01fc47c8c3610f990fc5e9b78b9953e2e82"
 dependencies = [
  "anyhow",
- "attohttpc",
  "bincode",
  "cocoa",
  "dirs-next",
@@ -10548,12 +10472,6 @@ name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
-
-[[package]]
-name = "wildmatch"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c48bd20df7e4ced539c12f570f937c6b4884928a87fee70a479d72f031d4e0"
 
 [[package]]
 name = "winapi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ features = [
 winreg = "0.10.1"
 
 [dependencies.tauri]
-features = ["api-all", "gtk-tray", "system-tray"]
+features = ["clipboard-all", "dialog-all", "fs-all", "global-shortcut-all", "gtk-tray", "notification-all", "os-all", "path-all", "process-exit", "process-relaunch", "shell-all", "system-tray", "window-all"]
 version = "1.0.0-rc.11"
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-desktop"
-version = "0.6.9"
+version = "0.6.10"
 description = "Subspace desktop"
 authors = ["Subspace Labs <https://subspace.network>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,10 +47,31 @@
       "active": false
     },
     "allowlist": {
-      "all": true,
+      "dialog": {
+        "all": true
+      },
       "fs": {
         "all": true,
         "scope": ["$HOME/*"]
+      },
+      "globalShortcut": {
+        "all": true
+      },
+      "notification": {
+        "all": true
+      },
+      "os": {
+        "all": true
+      },
+      "path": {
+        "all": true
+      },
+      "process": {
+        "relaunch": true,
+        "exit": true
+      },
+      "clipboard": {
+        "all": true
       },
       "shell": {
         "all": true,
@@ -63,6 +84,9 @@
             "args": true
           }
         ]
+      },
+      "window": {
+        "all": true
       }
     },
     "windows": [
@@ -77,7 +101,7 @@
       }
     ],
     "security": {
-      "csp": "default-src https tauri 'self'; img-src 'self'; object-src 'none'; connect-src ws://localhost:9947/; script-src 'wasm-unsafe-eval' 'unsafe-eval' 'self'"
+      "csp": "default-src tauri 'self'; img-src 'self'; object-src 'none'; connect-src ws://localhost:9947/; script-src 'wasm-unsafe-eval' 'unsafe-eval' 'self'"
     }
   }
 }


### PR DESCRIPTION
Fixes #272 
Previously, we were allowing all the `api` provided by tauri. It was not recommended for security reasons anyway. I've checked out the document, and tried to narrow down the scope of the allowlist and csp. 

By removing the `http` from the allowlist, the `openssl` dependency is no longer present. And hence, the bug is resolved. 