### PR TITLE
Tauri updater

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -78,11 +78,16 @@ jobs:
       - name: install app dependencies and build it
         # sometimes it fails downloading packages, so set a timeout https://github.com/yarnpkg/yarn/issues/4890
         run: yarn install --network-timeout 1000000 && yarn build
+        env:
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
       - name: tauri run
         uses: tauri-apps/tauri-action@v0.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
       - name: fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,9 @@ jobs:
       - name: install app dependencies and build it
         # sometimes it fails downloading packages, so set a timeout https://github.com/yarnpkg/yarn/issues/4890
         run: yarn install --network-timeout 1000000 && yarn build
+        env:
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
       - name: tauri run
         uses: tauri-apps/tauri-action@v0.3
@@ -73,6 +76,8 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.MACOS_IDENTITY_ID }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
           tagName: __VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
           releaseName: "__VERSION__"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -4482,6 +4482,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
 
 [[package]]
 name = "miniz_oxide"
@@ -9271,6 +9277,7 @@ checksum = "a4c7350af2191f3b7a288cadd672a01fc47c8c3610f990fc5e9b78b9953e2e82"
 dependencies = [
  "anyhow",
  "attohttpc",
+ "base64",
  "bincode",
  "cocoa",
  "dirs-next",
@@ -9284,6 +9291,7 @@ dependencies = [
  "heck 0.4.0",
  "http",
  "ignore",
+ "minisign-verify",
  "notify-rust",
  "objc",
  "once_cell",
@@ -9315,6 +9323,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "windows 0.30.0",
+ "zip",
 ]
 
 [[package]]
@@ -10997,6 +11006,17 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ features = [
 winreg = "0.10.1"
 
 [dependencies.tauri]
-features = ["api-all", "gtk-tray", "system-tray"]
+features = ["api-all", "gtk-tray", "system-tray", "updater"]
 version = "1.0.0-rc.11"
 
 [features]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,12 @@
       }
     },
     "updater": {
-      "active": false
+      "active": true,
+      "endpoints": [
+          "https://releases.myapp.com/{{target}}/{{current_version}}"
+      ],
+      "dialog": true,
+      "pubkey": "YOUR_UPDATER_SIGNATURE_PUBKEY_HERE"
     },
     "allowlist": {
       "all": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,10 +46,10 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://tauri-update-server.serge988.workers.dev/v1/{{target}}/{{arch}}/v0.6.8"
+        "https://tauri-update-server.serge988.workers.dev/v1/{{target}}/{{arch}}/{{current_version}}"
       ],
       "dialog": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERFQUI0RDg5NkQzMDJBQ0IKUldUTEtqQnRpVTJyM2tKMHdpQnNZQm4rVHRtS2NvSEZGTzhzVHZKazFkZXhzZVU0TjBhN3ZLYUsK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU4OTU2Qjc2QUFERTE4RjcKUldUM0dONnFkbXVWV0huTEN1bEZveUpZb1pXd0NOOFd1OXYvSUk2RjJRRnR6QUltelNaZXl2MTQK"
     },
     "allowlist": {
       "all": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,10 +46,10 @@
     "updater": {
       "active": true,
       "endpoints": [
-          "https://releases.myapp.com/{{target}}/{{current_version}}"
+        "https://tauri-update-server.serge988.workers.dev/v1/{{target}}/{{arch}}/v0.6.8"
       ],
       "dialog": true,
-      "pubkey": "YOUR_UPDATER_SIGNATURE_PUBKEY_HERE"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERFQUI0RDg5NkQzMDJBQ0IKUldUTEtqQnRpVTJyM2tKMHdpQnNZQm4rVHRtS2NvSEZGTzhzVHZKazFkZXhzZVU0TjBhN3ZLYUsK"
     },
     "allowlist": {
       "all": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://tauri-update-server.serge988.workers.dev/v1/{{target}}/{{arch}}/{{current_version}}"
+        "https://tauri-updater.subspace.network/v1/{{target}}/{{arch}}/{{current_version}}"
       ],
       "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDU4OTU2Qjc2QUFERTE4RjcKUldUM0dONnFkbXVWV0huTEN1bEZveUpZb1pXd0NOOFd1OXYvSUk2RjJRRnR6QUltelNaZXl2MTQK"


### PR DESCRIPTION
- adds updater to Tauri config
- adds Tauri update keys to GitHub actions workflow

Currently, it will check for updates on the app launch. We still need to clarify UX for periodical checks and dropdown menu item for updates (check for update, install update, etc.)