### PR TITLE
Make sure upcoming releases run on Ubuntu 20.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-20.04
           - macos-11
           - windows-2022
 


### PR DESCRIPTION
Newer Ubuntu uses newer glibc, we need to roll back to 20.04 that used older glibc to make it compatible again. I'm not aware of the way to restrict glibc version used (though I did 0 research, maybe it is in fact possible) and I don't think messing with musl libc is worth it for desktop app either.