### PR TITLE
Workflow update (abandon tauri actions)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -3,9 +3,11 @@ on:
   push:
     paths-ignore:
       - "**.md"
+      - "**/publish.yml"
   pull_request:
     paths-ignore:
       - "**.md"
+      - "**/publish.yml"
 
 env:
   # Not needed in CI, should make things a bit faster
@@ -21,7 +23,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-11
+          - macos-12
           - windows-2022
 
     runs-on: ${{ matrix.os }}
@@ -109,7 +111,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-11
+          - macos-12
           - windows-2022
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,37 +132,13 @@ jobs:
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-
-      - name: Sign Application (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          echo "Importing certificate"
-          echo "${{ secrets.MACOS_CERTIFICATE }}" | base64 --decode > certificate.p12
-          security create-keychain -p "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
-          security import certificate.p12 -k build.keychain -P "${{ secrets.MACOS_CERTIFICATE_PW }}" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
-          echo "Signing farmer"
-          codesign --force --options=runtime --entitlements .github/workflows/Entitlements.plist -s "${{ secrets.MACOS_IDENTITY }}" --timestamp ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_0.6.10_aarch64.dmg
-          echo "Creating an archive"
-          mkdir ${{ env.PRODUCTION_TARGET }}/macos-installer
-          cp ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ github.ref_name }}_aarch64.dmg ${{ env.PRODUCTION_TARGET }}/macos-installer
-          ditto -c -k --rsrc ${{ env.PRODUCTION_TARGET }}/macos-installer subspace-installer.zip
-          echo "Notarizing"
-          xcrun altool --notarize-app --primary-bundle-id binaries-${{ github.ref_name }} --username "${{ secrets.MACOS_APPLE_ID}}" --password "${{ secrets.APPLE_PASSWORD }}" --file subspace-installer.zip
-          # TODO: Wait for notarization before stapling
-          # echo "Stapling installer"
-          # xcrun stapler staple ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ github.ref_name }}_aarch64.dmg
-          echo "Done!"
-
-      - name: Sign Application (Windows)
-        uses: skymatic/code-sign-action@v1.1.0
-        with:
-          certificate: ${{ secrets.WINDOWS_CERTIFICATE }}
-          password: ${{ secrets.WINDOWS_CERTIFICATE_PW }}
-          certificatesha1: 00A427587B911908F59B6C42BA2863109C599C1C
-          folder: ${{ env.PRODUCTION_TARGET }}/msi
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_CODE_SIGNING: ${{ secrets.MACOS_CERTIFICATE }}
+          APPLE_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.MACOS_IDENTITY_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
       - name: Prepare installers for uploading (Ubuntu)
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 name: "publish"
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
 
 jobs:
   publish-tauri:
@@ -46,17 +50,6 @@ jobs:
         id: extract_version
         uses: Saionaro/extract-package-version@v1.0.6
 
-      - name: Create release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          tag_name: ${{ steps.extract_version.outputs.version }}
-          release_name: ${{ steps.extract_version.outputs.version }}
-          draft: false
-          prerelease: true
-        if: matrix.build.target == 'macos-aarch64'
-
       # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
@@ -71,7 +64,7 @@ jobs:
       - name: install Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-09
+          toolchain: nightly-2022-07-22
           target: ${{ matrix.build.target }}
           components: rust-src
           override: true
@@ -89,10 +82,11 @@ jobs:
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
         if: runner.os == 'Windows'
 
-      - name: install webkit2gtk (Linux)
+      # libayatana does not work for ubuntu20.04 -> https://github.com/subspace/subspace-desktop/runs/7581578859?check_suite_focus=true
+      - name: install webkit2gtk and libappindicator (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libayatana-appindicator3-dev
+          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libappindicator3-dev
         if: runner.os == 'Linux'
 
       # Imports PFX Certificate into keystore, allows Tauri to then sign the exe without being passed the private key.
@@ -107,6 +101,7 @@ jobs:
           certutil -decode certificate/tempCert.txt certificate/certificate.pfx
           Remove-Item –path certificate -include tempCert.txt
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
+
       - name: install app dependencies
         # sometimes it fails downloading packages, so set a timeout https://github.com/yarnpkg/yarn/issues/4890
         run: yarn install --network-timeout 1000000
@@ -160,6 +155,7 @@ jobs:
           # echo "Stapling installer"
           # xcrun stapler staple ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ github.ref_name }}_aarch64.dmg
           echo "Done!"
+
       - name: Sign Application (Windows)
         uses: skymatic/code-sign-action@v1.1.0
         with:
@@ -200,22 +196,18 @@ jobs:
           move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_x64_en-US.msi executables/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.msi
         if: runner.os == 'Windows'
 
-      - name: Upload installers to artifacts
+      - name: Upload executables to artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: executables_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}
+          name: executables-${{ matrix.build.suffix }}
           path: |
             executables/*
           if-no-files-found: error
 
-      - name: Create a release and Upload installers to assets
-        uses: softprops/action-gh-release@v1
+      - name: Upload executables to assets
+        uses: alexellis/upload-assets@0.3.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          body: "See the assets to download this version and install. \n ⚠️ This version is not tested yet, please use the version with latest tag on it! ⚠️"
-          prerelease: true
-          draft: true
-          name: ${{ steps.extract_version.outputs.version }}
-          tag_name: ${{ steps.extract_version.outputs.version }}
-          fail_on_unmatched_files: true
-          files: executables/*
-# TODO: use the monorepo approach for publishing a release
+          asset_paths: '["executables/*"]'
+        if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Upload executables to assets
         uses: alexellis/upload-assets@0.3.0
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           asset_paths: '["executables/*"]'
         if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,19 +15,19 @@ jobs:
           # since releasing on arm-linux is not a priority, we skipped it for now
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
-            suffix: ubuntu-x86_64
+            suffix: ubuntu-x86_64-${{ github.ref_name }}
             rustflags: ""
           - os: macos-12
             target: x86_64-apple-darwin
-            suffix: macos-x86_64
+            suffix: macos-x86_64-${{ github.ref_name }}
             rustflags: ""
           - os: macos-12
             target: aarch64-apple-darwin
-            suffix: macos-aarch64
+            suffix: macos-aarch64-${{ github.ref_name }}
             rustflags: ""
           - os: windows-2022
             target: x86_64-pc-windows-msvc
-            suffix: windows-x86_64
+            suffix: windows-x86_64-${{ github.ref_name }}
             rustflags: ""
 
     runs-on: ${{ matrix.build.os }}
@@ -45,10 +45,6 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: git checkout
         uses: actions/checkout@v2
-
-      - name: Extract version
-        id: extract_version
-        uses: Saionaro/extract-package-version@v1.0.6
 
       # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
       - name: Install LLVM and Clang
@@ -82,11 +78,10 @@ jobs:
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
         if: runner.os == 'Windows'
 
-      # libayatana does not work for ubuntu20.04 -> https://github.com/subspace/subspace-desktop/runs/7581578859?check_suite_focus=true
-      - name: install webkit2gtk and libappindicator (Linux)
+      - name: install webkit2gtk and libayatana (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libappindicator3-dev
+          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libayatana-appindicator3-dev
         if: runner.os == 'Linux'
 
       # Imports PFX Certificate into keystore, allows Tauri to then sign the exe without being passed the private key.
@@ -119,12 +114,12 @@ jobs:
 
       - name: Rename OpenCL installer (Linux x86_64)
         run: |
-          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop_${{ steps.extract_version.outputs.version }}_amd64.deb ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_amd64.deb
+          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop*amd64.deb ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop-opencl_amd64.deb
         if: runner.os == 'Linux'
 
       - name: Rename OpenCL installer (Windows)
         run: |
-          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop_${{ steps.extract_version.outputs.version }}_x64_en-US.msi ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_x64_en-US.msi
+          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop*_x64_en-US.msi ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop-opencl_x64_en-US.msi
         if: runner.os == 'Windows'
 
       - name: Build (without OpenCL)
@@ -143,34 +138,34 @@ jobs:
       - name: Prepare installers for uploading (Ubuntu)
         run: |
           mkdir executables
-          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop_${{ steps.extract_version.outputs.version }}_amd64.deb executables/subspace_desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.deb
-          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_amd64.deb executables/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.deb
+          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop-opencl_amd64.deb executables/subspace-desktop-opencl_${{ matrix.build.suffix }}.deb
+          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop*_amd64.deb executables/subspace-desktop_${{ matrix.build.suffix }}.deb
         if: runner.os == 'Linux'
+
+      - name: Prepare installers for uploading (Windows)
+        run: |
+          mkdir executables
+          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop-opencl_x64_en-US.msi executables/subspace-desktop-opencl_${{ matrix.build.suffix }}.msi
+          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop_x64*_en-US.msi executables/subspace-desktop_${{ matrix.build.suffix }}.msi
+        if: runner.os == 'Windows'
 
       - name: Prepare installers for uploading (macOS intel)
         run: |
           mkdir executables
-          mv ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ steps.extract_version.outputs.version }}_x64.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+          mv ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop*_x64.dmg executables/subspace-desktop_${{ matrix.build.suffix }}.dmg
           # Zip it so that signature is not lost
-          ditto -c -k --rsrc executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.zip
-          rm executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+          ditto -c -k --rsrc executables/subspace-desktop_${{ matrix.build.suffix }}.dmg executables/subspace-desktop_${{ matrix.build.suffix }}.zip
+          rm executables/subspace-desktop_${{ matrix.build.suffix }}.dmg
         if: matrix.build.target == 'x86_64-apple-darwin'
 
       - name: Prepare installers for uploading (macOS arm)
         run: |
           mkdir executables
-          mv ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ steps.extract_version.outputs.version }}_aarch64.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+          mv ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop*_aarch64.dmg executables/subspace-desktop_${{ matrix.build.suffix }}.dmg
           # Zip it so that signature is not lost
-          ditto -c -k --rsrc executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.zip
-          rm executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+          ditto -c -k --rsrc executables/subspace-desktop_${{ matrix.build.suffix }}.dmg executables/subspace-desktop_${{ matrix.build.suffix }}.zip
+          rm executables/subspace-desktop_${{ matrix.build.suffix }}.dmg
         if: matrix.build.target == 'aarch64-apple-darwin'
-
-      - name: Prepare installers for uploading (Windows)
-        run: |
-          mkdir executables
-          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop_${{ steps.extract_version.outputs.version }}_x64_en-US.msi executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.msi
-          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_x64_en-US.msi executables/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.msi
-        if: runner.os == 'Windows'
 
       - name: Upload executables to artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,15 +6,56 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-20.04
-          - macos-11
-          - windows-2022
+        build:
+          # for ubuntu with arch, we need more testing with cross compilation libraries
+          # since releasing on arm-linux is not a priority, we skipped it for now
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            suffix: ubuntu-x86_64
+            rustflags: ""
+          - os: macos-12
+            target: x86_64-apple-darwin
+            suffix: macos-x86_64
+            rustflags: ""
+          - os: macos-12
+            target: aarch64-apple-darwin
+            suffix: macos-aarch64
+            rustflags: ""
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
+            suffix: windows-x86_64
+            rustflags: ""
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build.os }}
+
+    env:
+      PRODUCTION_TARGET: src-tauri/target/${{ matrix.build.target }}/release/bundle
+      RUSTFLAGS: ${{ matrix.build.rustflags }}
+
     steps:
+      - name: Maximize build space
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: git checkout
         uses: actions/checkout@v2
+
+      - name: Extract version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+
+      - name: Create release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ steps.extract_version.outputs.version }}
+          release_name: ${{ steps.extract_version.outputs.version }}
+          draft: false
+          prerelease: true
+        if: matrix.build.target == 'macos-aarch64'
 
       # For sloth256-189 Wasm support we need `llvm-ar`, which is not available by default
       - name: Install LLVM and Clang
@@ -30,19 +71,29 @@ jobs:
       - name: install Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-22
+          toolchain: nightly-2022-07-09
+          target: ${{ matrix.build.target }}
+          components: rust-src
           override: true
 
-        # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
+      - name: CUDA toolchain
+        uses: Jimver/cuda-toolkit@v0.2.6
+        if: runner.os == 'Linux' || runner.os == 'Windows'
+
+      - name: install libdbus-1-dev and pkg-config (Linux)
+        run: sudo apt -y --no-install-recommends install libdbus-1-dev pkg-config
+        if: runner.os == 'Linux'
+
+      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
         if: runner.os == 'Windows'
 
-      - name: install webkit2gtk (ubuntu only)
-        if: runner.os == 'Linux'
+      - name: install webkit2gtk (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libappindicator3-dev
+          sudo apt-get install -y --no-install-recommends libwebkit2gtk-4.0-dev libayatana-appindicator3-dev
+        if: runner.os == 'Linux'
 
       # Imports PFX Certificate into keystore, allows Tauri to then sign the exe without being passed the private key.
       - name: import windows certificate
@@ -56,29 +107,115 @@ jobs:
           certutil -decode certificate/tempCert.txt certificate/certificate.pfx
           Remove-Item –path certificate -include tempCert.txt
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
-
-      - name: install app dependencies and build it
+      - name: install app dependencies
         # sometimes it fails downloading packages, so set a timeout https://github.com/yarnpkg/yarn/issues/4890
-        run: yarn install --network-timeout 1000000 && yarn build
+        run: yarn install --network-timeout 1000000
+
+      - name: OpenCL (Linux x86_64)
+        run: sudo apt-get install -y --no-install-recommends ocl-icd-opencl-dev
+        if: runner.os == 'Linux'
+
+      - name: Build (Ubuntu or Windows with OpenCL)
+        run: yarn build -c ./src-tauri/tauri.opencl.conf.json -- --target ${{ matrix.build.target }}
+        if: (runner.os == 'Linux' || runner.os == 'Windows')
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
-      - name: tauri run
-        uses: tauri-apps/tauri-action@v0.3
+      - name: Rename OpenCL installer (Linux x86_64)
+        run: |
+          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop_${{ steps.extract_version.outputs.version }}_amd64.deb ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_amd64.deb
+        if: runner.os == 'Linux'
+
+      - name: Rename OpenCL installer (Windows)
+        run: |
+          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop_${{ steps.extract_version.outputs.version }}_x64_en-US.msi ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_x64_en-US.msi
+        if: runner.os == 'Windows'
+
+      - name: Build (without OpenCL)
+        run: yarn build -- --target ${{ matrix.build.target }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ENABLE_CODE_SIGNING: ${{ secrets.MACOS_CERTIFICATE }}
-          APPLE_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.MACOS_IDENTITY_ID }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+
+      - name: Sign Application (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          echo "Importing certificate"
+          echo "${{ secrets.MACOS_CERTIFICATE }}" | base64 --decode > certificate.p12
+          security create-keychain -p "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
+          security import certificate.p12 -k build.keychain -P "${{ secrets.MACOS_CERTIFICATE_PW }}" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.MACOS_CERTIFICATE_PW }}" build.keychain
+          echo "Signing farmer"
+          codesign --force --options=runtime --entitlements .github/workflows/Entitlements.plist -s "${{ secrets.MACOS_IDENTITY }}" --timestamp ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_0.6.10_aarch64.dmg
+          echo "Creating an archive"
+          mkdir ${{ env.PRODUCTION_TARGET }}/macos-installer
+          cp ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ github.ref_name }}_aarch64.dmg ${{ env.PRODUCTION_TARGET }}/macos-installer
+          ditto -c -k --rsrc ${{ env.PRODUCTION_TARGET }}/macos-installer subspace-installer.zip
+          echo "Notarizing"
+          xcrun altool --notarize-app --primary-bundle-id binaries-${{ github.ref_name }} --username "${{ secrets.MACOS_APPLE_ID}}" --password "${{ secrets.APPLE_PASSWORD }}" --file subspace-installer.zip
+          # TODO: Wait for notarization before stapling
+          # echo "Stapling installer"
+          # xcrun stapler staple ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ github.ref_name }}_aarch64.dmg
+          echo "Done!"
+      - name: Sign Application (Windows)
+        uses: skymatic/code-sign-action@v1.1.0
         with:
-          tagName: __VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-          releaseName: "__VERSION__"
-          releaseBody: "See the assets to download this version and install."
-          releaseDraft: false
+          certificate: ${{ secrets.WINDOWS_CERTIFICATE }}
+          password: ${{ secrets.WINDOWS_CERTIFICATE_PW }}
+          certificatesha1: 00A427587B911908F59B6C42BA2863109C599C1C
+          folder: ${{ env.PRODUCTION_TARGET }}/msi
+
+      - name: Prepare installers for uploading (Ubuntu)
+        run: |
+          mkdir executables
+          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop_${{ steps.extract_version.outputs.version }}_amd64.deb executables/subspace_desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.deb
+          mv ${{ env.PRODUCTION_TARGET }}/deb/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_amd64.deb executables/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.deb
+        if: runner.os == 'Linux'
+
+      - name: Prepare installers for uploading (macOS intel)
+        run: |
+          mkdir executables
+          mv ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ steps.extract_version.outputs.version }}_x64.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+          # Zip it so that signature is not lost
+          ditto -c -k --rsrc executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.zip
+          rm executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+        if: matrix.build.target == 'x86_64-apple-darwin'
+
+      - name: Prepare installers for uploading (macOS arm)
+        run: |
+          mkdir executables
+          mv ${{ env.PRODUCTION_TARGET }}/dmg/subspace-desktop_${{ steps.extract_version.outputs.version }}_aarch64.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+          # Zip it so that signature is not lost
+          ditto -c -k --rsrc executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.zip
+          rm executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.dmg
+        if: matrix.build.target == 'aarch64-apple-darwin'
+
+      - name: Prepare installers for uploading (Windows)
+        run: |
+          mkdir executables
+          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop_${{ steps.extract_version.outputs.version }}_x64_en-US.msi executables/subspace-desktop_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.msi
+          move ${{ env.PRODUCTION_TARGET }}/msi/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_x64_en-US.msi executables/subspace-desktop-opencl_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}.msi
+        if: runner.os == 'Windows'
+
+      - name: Upload installers to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: executables_${{ steps.extract_version.outputs.version }}_${{ matrix.build.suffix }}
+          path: |
+            executables/*
+          if-no-files-found: error
+
+      - name: Create a release and Upload installers to assets
+        uses: softprops/action-gh-release@v1
+        with:
+          body: "See the assets to download this version and install. \n ⚠️ This version is not tested yet, please use the version with latest tag on it! ⚠️"
           prerelease: true
+          draft: true
+          name: ${{ steps.extract_version.outputs.version }}
+          tag_name: ${{ steps.extract_version.outputs.version }}
+          fail_on_unmatched_files: true
+          files: executables/*
+# TODO: use the monorepo approach for publishing a release

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3604,9 +3604,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libappindicator"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b29fab3280d59f3d06725f75da9ef9a1b001b2c748b1abfebd1c966c61d7de"
+checksum = "db2d3cb96d092b4824cb306c9e544c856a4cb6210c1081945187f7f1924b47e8"
 dependencies = [
  "glib",
  "gtk",
@@ -3617,12 +3617,13 @@ dependencies = [
 
 [[package]]
 name = "libappindicator-sys"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bdcb8c5cfc11febe2ff3f18386d6cb7d29f464cbaf6b286985c3f1a501d74f"
+checksum = "f1b3b6681973cea8cc3bce7391e6d7d5502720b80a581c9a95c9cbaf592826aa"
 dependencies = [
  "gtk-sys",
- "pkg-config",
+ "libloading 0.7.3",
+ "once_cell",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -706,6 +706,9 @@ name = "bytes"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytesize"
@@ -926,7 +929,7 @@ dependencies = [
 [[package]]
 name = "cirrus-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -943,7 +946,7 @@ dependencies = [
 [[package]]
 name = "cirrus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -955,7 +958,7 @@ dependencies = [
 [[package]]
 name = "cirrus-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "cirrus-pallet-executive",
  "cirrus-primitives",
@@ -981,6 +984,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "subspace-runtime-primitives",
+ "subspace-wasm-tools",
  "substrate-wasm-builder",
 ]
 
@@ -3750,6 +3754,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "schnorrkel",
+ "serde",
  "sha2 0.10.2",
  "smallvec",
  "thiserror",
@@ -3820,6 +3825,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
+ "serde",
  "sha2 0.10.2",
  "smallvec",
  "unsigned-varint",
@@ -3865,6 +3871,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
+ "serde",
  "sha2 0.10.2",
  "smallvec",
  "thiserror",
@@ -4604,6 +4611,8 @@ dependencies = [
  "core2",
  "digest 0.10.3",
  "multihash-derive",
+ "serde",
+ "serde-big-array",
  "sha2 0.10.2",
  "sha3",
  "unsigned-varint",
@@ -5141,7 +5150,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5207,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5223,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5239,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -5259,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5274,7 +5283,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5289,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5302,7 +5311,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5313,7 +5322,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5367,7 +5376,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6759,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6799,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -6840,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -7289,7 +7298,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -7644,6 +7653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8139,7 +8157,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "async-trait",
  "log",
@@ -8257,7 +8275,7 @@ dependencies = [
 [[package]]
 name = "sp-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8371,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -8822,7 +8840,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "merkle_light",
  "parity-scale-codec",
@@ -8836,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "derive_more",
  "hex",
@@ -8895,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.3.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8946,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -8964,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8974,11 +8992,15 @@ dependencies = [
  "generic-array 0.14.5",
  "hex",
  "libp2p",
+ "lru",
  "nohash-hasher",
  "once_cell",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
+ "serde",
+ "serde_json",
  "subspace-core-primitives",
  "thiserror",
  "tokio",
@@ -8990,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "hex",
  "serde",
@@ -9000,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "cirrus-primitives",
  "cirrus-runtime",
@@ -9050,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -9064,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "cirrus-primitives",
  "derive_more",
@@ -9119,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "merlin",
  "num-traits",
@@ -9135,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -9152,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=3c98a67882cd7454a6882f56a726bb337cce6242#3c98a67882cd7454a6882f56a726bb337cce6242"
+source = "git+https://github.com/subspace/subspace?rev=acba55830753667eafdd2229d4bf7868d0258038#acba55830753667eafdd2229d4bf7868d0258038"
 
 [[package]]
 name = "substrate-bip39"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,8 +12,8 @@ substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/su
 tauri-build = { version = "1.0.0-rc.9", features = [] }
 
 [dependencies]
-anyhow = "1.0.44"
-cirrus-runtime = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
+anyhow = "1.0.58"
+cirrus-runtime = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
 dirs = "4.0.0"
 dotenv = "0.15.0"
 event-listener-primitives = "2.0.1"
@@ -26,19 +26,19 @@ sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspac
 sc-executor = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86", features = ["wasmtime"] }
 sc-network = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
 sc-service = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86", features = ["wasmtime"] }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
 serde_json = "1.0.82"
 serde = { version = "1.0.139", features = [ "derive" ] }
 sp-core = { version = "6.0.0", git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
 sp-panic-handler = { version = "4.0.0", git = "https://github.com/subspace/substrate", rev = "1399afdcd8ab4d7fad149c96f9cadcaf04b94f86" }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
-subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
-subspace-solving = { git = "https://github.com/subspace/subspace", rev = "3c98a67882cd7454a6882f56a726bb337cce6242" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
+subspace-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
+subspace-solving = { git = "https://github.com/subspace/subspace", rev = "acba55830753667eafdd2229d4bf7868d0258038" }
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.31"
 tracing-bunyan-formatter = "0.3.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,8 @@
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "noImplicitReturns": true
-  }
+  },
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
Fixes #255 
Fixes #275 

We finally have a new workflow, which allows us to have more granular control over the build process and everything related to executables. The biggest reason was, to be able to publish 2 versions (1 for normal, 1 with opencl).

Note:
Cargo toml changes might seem weird for a workflow PR -> the reason is cirrus-runtime inclusion bug had to be solved on the monorepo side