### PR TITLE
discord workflow

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,26 @@
+name: "discord-notify"
+on:
+  workflow_run:
+    workflows: [publish]
+    types:
+      - completed
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Extract version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+
+      - name: Discord notification
+        env:
+          DISCORD_USERNAME: Subspace_Desktop-Releaser
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: "Subspace desktop version: ${{ steps.extract_version.outputs.version }} has been released! Check it out in this link: https://github.com/subspace/subspace-desktop/releases/tag/${{ steps.extract_version.outputs.version }}"


### PR DESCRIPTION
Outcome: 
<img width="977" alt="image" src="https://user-images.githubusercontent.com/32795992/183914418-5dccad1d-fb66-4875-ad6b-d2bad76c58f3.png">


Tested on `discord-testing` channel. 
Nazar provided the webhook for the `prelease-testing` channel, and updated the secret in the repo, so we should be good to go. 

This workflow will be triggered when `publish` is completed, and the jobs will run ONLY IF `publish` is successful.

The message itself is probably not the best, any edit/suggestion is welcomed

---

closes #292 