### PR TITLE
added more inline docs

### DIFF
--- a/src-tauri/src/farmer.rs
+++ b/src-tauri/src/farmer.rs
@@ -32,12 +32,15 @@ enum ArchivingFrom {
     Dsn,
 }
 
+/// the default strategy for syncing
 impl Default for ArchivingFrom {
     fn default() -> Self {
         Self::Rpc
     }
 }
 
+/// manages the `farm` process
+/// waits on the `farm` handle, and restarts the `farm` process if needed
 #[tauri::command]
 pub(crate) async fn farming(
     path: String,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,11 +23,12 @@ use tracing_subscriber::{fmt, fmt::format::FmtSpan, EnvFilter};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let ctx = tauri::generate_context!();
+    let ctx = tauri::generate_context!(); // context is necessary to get bundle id
     let id = &ctx.config().tauri.bundle.identifier;
     let log_dir = utils::custom_log_dir(id);
     create_dir_all(log_dir.clone()).expect("path creation should always succeed");
 
+    // filter for logging
     let filter = || {
         EnvFilter::builder()
             .with_default_directive(LevelFilter::INFO.into())
@@ -54,6 +55,7 @@ async fn main() -> Result<()> {
         )
         .init();
 
+    // building the application
     let app = tauri::Builder::default()
         .setup(|app| {
             #[cfg(debug_assertions)] // only include this code on debug builds
@@ -118,6 +120,7 @@ async fn main() -> Result<()> {
         .build(ctx)
         .expect("error while running tauri application");
 
+    // running the application
     app.run(|app_handle, e| match e {
         RunEvent::WindowEvent {
             label,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -15,6 +15,7 @@ pub fn get_tray_menu() -> SystemTray {
 }
 
 pub fn get_menu() -> Menu {
+    // we don't need menu for Windows and Linux (without a menu, keyboard shortcuts doesn't work on macOS)
     #[cfg(target_os = "macos")]
     {
         let my_app_menu = Menu::new()
@@ -41,6 +42,7 @@ pub fn get_menu() -> Menu {
             .add_submenu(Submenu::new("Edit", edit_menu))
             .add_submenu(Submenu::new("Window", window_menu))
     }
+    // return an empty menu for Windows and Linux
     #[cfg(not(target_os = "macos"))]
     {
         Menu::new()

--- a/src-tauri/src/node.rs
+++ b/src-tauri/src/node.rs
@@ -56,10 +56,10 @@ impl NativeExecutionDispatch for ExecutorDispatch {
     }
 }
 
-#[tauri::command]
-/// starts a new node instance
+/// starts a new node instance via calling `init_node()`
 /// if there is a node instance running previously,
 /// first it stops the previous instance, then starts a new instance
+#[tauri::command]
 pub(crate) async fn start_node(path: String, node_name: String) -> Result<String, String> {
     type FullClient<RuntimeApi, ExecutorDispatch> =
         sc_service::TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<ExecutorDispatch>>;


### PR DESCRIPTION
The existing inline docs on the Rust side were already sufficient. 
I added a few more the make it more comprehensive. 
The code itself is good and does not need much commenting (adding more comments would make it too verbose and unreadable imo). 

I'm open to any suggestions/additions, let me know if you think we need more comments in other places :)

Should close #297 