### PR TITLE
Add max plot size limit for Gemini II

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -33,7 +33,8 @@
     "estimatingSpace": "Requesting the blockchain size from the network.",
     "plotsDirectory": "Plots Directory",
     "start": "Start Plotting",
-    "allocatedErrorMsg": "Value should be a positive number"
+    "allocatedErrorMsg": "Value should be a positive number",
+    "plotSizeLimitErrorMsg": "Max plot size for Gemini II testnet is 100 GB"
   },
   "plottingProgress": {
     "startingFarmer": "Starting the farmer ...",

--- a/src/pages/SetupPlot.vue
+++ b/src/pages/SetupPlot.vue
@@ -64,7 +64,7 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
                 outlined
                 suffix="GB"
                 v-model.number="store.plotSizeGB"
-                :rules="[val => val > 0 || $t('setupPlot.allocatedErrorMsg')]"
+                :rules="[val => val > 0 || $t('setupPlot.allocatedErrorMsg'), val => val <= 100 || $t('setupPlot.plotSizeLimitErrorMsg')]"
               )
                 q-tooltip.q-pa-sm
                   p {{ $t('setupPlot.allocatedSpace') }}
@@ -100,7 +100,7 @@ q-page.q-pa-lg.q-mr-lg.q-ml-lg
     .col-expand
     .col-auto
       q-btn(
-        :disable="(!validPath || store.plotSizeGB <= 0)"
+        :disable="(!validPath || store.plotSizeGB <= 0 || store.plotSizeGB > 100)"
         @click="confirmCreateDir()"
         color="blue-8"
         icon-right="downloading"


### PR DESCRIPTION
<img width="802" alt="Screenshot 2022-08-23 at 14 48 23" src="https://user-images.githubusercontent.com/13568875/186150745-d5471167-9488-48d2-a30d-c6e12393896f.png">
Add an error message and disable 'Start plotting' button if plot size is more than 100 GB. Closes #322 