### PR TITLE
rotating logs and cargo toml cleanup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1316,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -7421,7 +7421,7 @@ dependencies = [
  "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-log",
+ "tracing-log 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.2.25",
 ]
 
@@ -7989,9 +7989,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "snap"
@@ -8917,10 +8917,8 @@ dependencies = [
  "cirrus-runtime",
  "dirs 4.0.0",
  "dotenv",
- "event-listener-primitives",
  "fdlimit",
  "fs2",
- "hex",
  "openssl",
  "sc-chain-spec",
  "sc-client-api",
@@ -8946,6 +8944,7 @@ dependencies = [
  "tauri-build",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-bunyan-formatter",
  "tracing-subscriber 0.3.15",
  "winreg 0.10.1",
@@ -9868,8 +9867,7 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 [[package]]
 name = "tracing"
 version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "cfg-if",
  "log",
@@ -9879,10 +9877,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time 0.3.9",
+ "tracing-subscriber 0.3.15",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9902,15 +9910,14 @@ dependencies = [
  "time 0.3.9",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.3.15",
 ]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9934,6 +9941,16 @@ checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+dependencies = [
+ "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -9966,15 +9983,14 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-serde",
 ]
 
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "ansi_term",
  "matchers 0.1.0",
@@ -9985,7 +10001,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3 (git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x)",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9867,7 +9867,7 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 [[package]]
 name = "tracing"
 version = "0.1.36"
-source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+source = "git+https://github.com/subspace/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "cfg-if",
  "log",
@@ -9879,7 +9879,7 @@ dependencies = [
 [[package]]
 name = "tracing-appender"
 version = "0.2.2"
-source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+source = "git+https://github.com/subspace/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "crossbeam-channel",
  "thiserror",
@@ -9890,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.22"
-source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+source = "git+https://github.com/subspace/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9917,7 +9917,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.29"
-source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+source = "git+https://github.com/subspace/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9947,7 +9947,7 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.1.3"
-source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+source = "git+https://github.com/subspace/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "log",
  "once_cell",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.15"
-source = "git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
+source = "git+https://github.com/subspace/tracing-keep-last-n-logs?branch=v0.1.x#06e280373923410c7e65ee27c82c836f913182c8"
 dependencies = [
  "ansi_term",
  "matchers 0.1.0",
@@ -10001,7 +10001,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.3 (git+https://github.com/ozgunozerk/tracing-keep-last-n-logs?branch=v0.1.x)",
+ "tracing-log 0.1.3 (git+https://github.com/subspace/tracing-keep-last-n-logs?branch=v0.1.x)",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,9 @@ codegen-units = 1
 # TODO: Remove once chacha20poly1305 0.10 appears in libp2p's dependencies
 chacha20poly1305 = { git = "https://github.com/RustCrypto/AEADs", rev = "06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99" }
 libp2p = { git = "https://github.com/subspace/rust-libp2p", branch = "subspace-v3" }
-tracing = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }
-tracing-core = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }
-tracing-appender = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }
-tracing-subscriber = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }
+# if https://github.com/tokio-rs/tracing/pull/2284 merges, we can get rid of the below
+# we need these, since tracing does not have keep-last-n-logs feature yet
+tracing = { git = "https://github.com/subspace/tracing-keep-last-n-logs", branch = "v0.1.x" }
+tracing-core = { git = "https://github.com/subspace/tracing-keep-last-n-logs", branch = "v0.1.x" }
+tracing-appender = { git = "https://github.com/subspace/tracing-keep-last-n-logs", branch = "v0.1.x" }
+tracing-subscriber = { git = "https://github.com/subspace/tracing-keep-last-n-logs", branch = "v0.1.x" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,10 +16,8 @@ anyhow = "1.0.58"
 cirrus-runtime = { git = "https://github.com/subspace/subspace", rev = "efbead79c291ff731c7687d2704e82513ecc196a" }
 dirs = "4.0.0"
 dotenv = "0.15.0"
-event-listener-primitives = "2.0.1"
 fdlimit = "0.2.1"
 fs2 = "0.4.3"
-hex = "0.4.3"
 sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6b8553511112afd5ae7e8e6877dc2f467850f155" }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/subspace/substrate", rev = "6b8553511112afd5ae7e8e6877dc2f467850f155" }
 sc-consensus-slots = { version = "0.10.0-dev", git = "https://github.com/subspace/substrate", rev = "6b8553511112afd5ae7e8e6877dc2f467850f155" }
@@ -41,6 +39,7 @@ subspace-service = { git = "https://github.com/subspace/subspace", rev = "efbead
 subspace-solving = { git = "https://github.com/subspace/subspace", rev = "efbead79c291ff731c7687d2704e82513ecc196a" }
 tokio = { version = "1.11.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.31"
+tracing-appender = "0.2"
 tracing-bunyan-formatter = "0.3.2"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 
@@ -71,3 +70,7 @@ codegen-units = 1
 # TODO: Remove once chacha20poly1305 0.10 appears in libp2p's dependencies
 chacha20poly1305 = { git = "https://github.com/RustCrypto/AEADs", rev = "06dbfb5571687fd1bbe9d3c9b2193a1ba17f8e99" }
 libp2p = { git = "https://github.com/subspace/rust-libp2p", branch = "subspace-v3" }
+tracing = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }
+tracing-core = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }
+tracing-appender = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }
+tracing-subscriber = { git = "https://github.com/ozgunozerk/tracing-keep-last-n-logs", branch = "v0.1.x" }


### PR DESCRIPTION
Previous PR had conflicts with main regarding cargo lock, it was easier to create a new branch on top of the up to date main. 
I made the parameter 7 days for keeping the logs (it was about 24-30 mb daily for my case)