### PR TITLE
Issue4 and architecture fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,7 +28,7 @@ Page components often contain other components which are registered here. Check 
 Contains utility functions for communicating with the native OS such as reading/writing files and device metadata.
 
 ### [`/stores`](src/stores)
-TODO: serge can you fill this?
+Enables state sharing across components and pages. Check the [Pinia Documentation](https://pinia.vuejs.org/introduction.html) for further details.
 
 ### [`/lib/client.ts`](src/lib/client.ts)
 Wrapper logic around `polkadotjs` which handles communication with the Subspace client. There is wrapper function for getting information about blocks, peers and other data. This library has to be initialized async using a websocket connection and will hang if the connection is unable to establish.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,18 +22,18 @@ Main Layout is the frame that all pages are rendered inside of. This includes th
 All Vue component pages go here. Usually the name of the .vue file should be the same as the router name listed in `router/routes.ts`. The component template must start with the [q-page element](https://quasar.dev/layout/page).
 
 ### [`/components`](src/components)
-Page components often contain other components which are registered here. Check the `Dashboard.vue` page for a good example of this.
+Page components often contain other components which are registered here. Check the `introModal.vue` page for a good example of this.
 
 ### [`/lib/native.ts`](src/lib/native.ts)
-Contains utility functions for communicating with the native OS such as reading/writing files and device metadata. Contains the `AutoLauncher` class which handles registering the app to start on boot on various platforms.
+Contains utility functions for communicating with the native OS such as reading/writing files and device metadata.
 
-### [`/lib/global.ts`](src/lib/global.ts)
-The global state object. Contains data, clases and functions that can easily be shared across all components. The `Global` class has an `init()` method which initializes the localization and autoLauncher logic.
+### [`/stores`](src/stores)
+TODO: serge can you fill this?
 
 ### [`/lib/client.ts`](src/lib/client.ts)
-Wrapper logic around polkadotjs which handles communication with the Subspace client. There is wrapper function for getting information about blocks, peers and other data. This library has to be initialized async using a websocket conneection and will hang if the connection is unable to establish. Currently we handle the initialization inside Dashboard.vue.
+Wrapper logic around `polkadotjs` which handles communication with the Subspace client. There is wrapper function for getting information about blocks, peers and other data. This library has to be initialized async using a websocket connection and will hang if the connection is unable to establish.
 
-### [`/lib/autolaunch`](src/lib/autolaunch)
+### [`/lib/autolaunch`](src/lib/autoLauncher.ts)
 Contains utility functions for handling the launch on boot functionality of the `AutoLauncher` class.
 
 ## Backend (Rust + Tauri) `/src-tauri`
@@ -46,7 +46,7 @@ The Tauri framework is configured here (no features enabled). For details about 
 The Tauri framework is configured here (opencl feature enabled). For details about configuration refer to the [config documentation](https://tauri.app/v1/api/config/).
 
 ### [`src-tauri/icons`](src-tauri/icons)
-Platform icons are stored here. The icons can be automatically generated using `yarn tauri icon` as documented [here](https://tauri.studio/en/docs/usage/guides/visual/icons/).
+Platform icons are stored here. The icons can be automatically generated using `yarn tauri icon` as documented [here](https://tauri.app/v1/guides/features/icons/).
 
 ### [`src-tauri/src`](src-tauri/src)
 Main rust files are stored here. `main.rs` is the main entry point for the application and contains custom backend logic. The Rust Tauri API is documented [here](https://tauri.studio/en/docs/api/rust/tauri/index).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5014,16 +5014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "open"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23a407004a1033f53e93f9b45580d14de23928faad187384f891507c9b0c045"
-dependencies = [
- "pathdiff",
- "windows-sys 0.36.1",
-]
-
-[[package]]
 name = "openmp-sys"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5560,12 +5550,6 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
@@ -9341,7 +9325,6 @@ dependencies = [
  "notify-rust",
  "objc",
  "once_cell",
- "open",
  "os_info",
  "os_pipe",
  "percent-encoding",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,7 +51,7 @@ openssl = { version = "0.10.40", features = ["vendored"] }
 winreg = "0.10.1"
 
 [dependencies.tauri]
-features = ["clipboard-all", "dialog-all", "fs-all", "global-shortcut-all", "notification-all", "os-all", "path-all", "process-exit", "process-relaunch", "shell-all", "system-tray", "updater", "window-all"]
+features = [ "clipboard-all", "dialog-all", "fs-all", "global-shortcut-all", "notification-all", "os-all", "path-all", "process-exit", "process-relaunch", "shell-execute", "system-tray", "updater", "window-all"]
 version = "1.0.5"
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     create_dir_all(log_dir.clone()).expect("path creation should always succeed");
 
     let mut file_appender = tracing_appender::rolling::daily(log_dir, "subspace-desktop.log");
-    file_appender.keep_last_n_logs(KEEP_LAST_N_DAYS); // keep the logs of last 5 days only
+    file_appender.keep_last_n_logs(KEEP_LAST_N_DAYS); // keep the logs of last 7 days only
 
     // filter for logging
     let filter = || {
@@ -96,26 +96,28 @@ async fn main() -> Result<()> {
         .invoke_handler(
             #[cfg(not(target_os = "windows"))]
             tauri::generate_handler![
-                utils::get_disk_stats,
-                utils::get_this_binary,
                 farmer::farming,
                 node::start_node,
                 utils::frontend_error_logger,
                 utils::frontend_info_logger,
-                utils::custom_log_dir
+                utils::custom_log_dir,
+                utils::open_folder,
+                utils::get_disk_stats,
+                utils::get_this_binary,
             ],
             #[cfg(target_os = "windows")]
             tauri::generate_handler![
                 windows::winreg_get,
                 windows::winreg_set,
                 windows::winreg_delete,
-                utils::get_disk_stats,
-                utils::get_this_binary,
                 farmer::farming,
                 node::start_node,
                 utils::frontend_error_logger,
                 utils::frontend_info_logger,
-                utils::custom_log_dir
+                utils::custom_log_dir,
+                utils::get_disk_stats,
+                utils::get_this_binary,
+                utils::open_folder,
             ],
         )
         .build(ctx)

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use std::path::PathBuf;
+use std::process::Command;
 use tauri::{api, Env};
 use tracing::{debug, error, info};
 
@@ -7,6 +8,27 @@ use tracing::{debug, error, info};
 pub(crate) struct DiskStats {
     free_bytes: u64,
     total_bytes: u64,
+}
+
+#[tauri::command]
+pub(crate) fn open_folder(dir: String) {
+    #[cfg(target_os = "windows")]
+    Command::new("explorer")
+        .arg(dir)
+        .spawn()
+        .expect("could not open to specified directory");
+
+    #[cfg(target_os = "macos")]
+    Command::new("open")
+        .arg(dir)
+        .spawn()
+        .expect("could not open to specified directory");
+
+    #[cfg(target_os = "linux")]
+    Command::new("xdg-open")
+        .arg(dir)
+        .spawn()
+        .expect("could not open to specified directory");
 }
 
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -81,7 +81,7 @@
       "shell": {
         "all": true,
         "execute": true,
-        "open": "[/subspace\\-desktop/]",
+        "open": false,
         "scope": [
           {
             "name": "run-osascript",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -79,7 +79,6 @@
         "all": true
       },
       "shell": {
-        "all": true,
         "execute": true,
         "open": false,
         "scope": [

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -35,7 +35,7 @@ q-menu(auto-close)
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { Dialog, Notify } from 'quasar';
-import { process, shell, event } from '@tauri-apps/api';
+import { process, event, tauri } from '@tauri-apps/api';
 import { LocalStorage as localStorage } from 'quasar';
 
 import * as plotDir from '../lib/plotDir';
@@ -113,7 +113,7 @@ export default defineComponent({
       try {
         const log_path = await util.getLogPath();
         util.infoLogger('log path acquired:' + log_path);
-        await shell.open(log_path);
+        tauri.invoke("open_folder", {dir: log_path});
       } catch (error) {
         // TODO: add proper error handling - update store and show error page
         util.errorLogger(error);

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -113,7 +113,7 @@ export default defineComponent({
       try {
         const log_path = await util.getLogPath();
         util.infoLogger('log path acquired:' + log_path);
-        tauri.invoke("open_folder", {dir: log_path});
+        await tauri.invoke("open_folder", {dir: log_path});
       } catch (error) {
         // TODO: add proper error handling - update store and show error page
         util.errorLogger(error);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -115,13 +115,6 @@ class Config {
    * @param {IConfig} - config object to store as config file
    */
   private async write(config: IConfig): Promise<void> {
-    await this.fs.createDir(this.configPath)
-      // ignore error if folder exists
-      .catch((error) => {
-        if (!error.includes('exists')) {
-          this.errorLogger(error);
-        }
-      });
     await this.fs.writeFile({
       path: this.configFullPath,
       contents: JSON.stringify(config, null, 2)

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -96,7 +96,7 @@ export function generateNodeName(): string {
   let nodeName = '';
   do {
     const slug = generateSlug(2);
-    const num = Math.floor(Math.random() * (9999 - 1000 + 1)) + 1000;
+    const num = Math.floor(Math.random() * (9000)) + 1000;
     nodeName = slug + '-' + num.toString();
   } while (nodeName.length > nodeNameMaxLength);
   return nodeName;

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -42,7 +42,7 @@ export default defineComponent({
   },
   async mounted() {
     try {
-      this.checkDev();
+      this.checkDevAndDisableContextMenu();
       if (await this.$config.validate()) {
         util.infoLogger('INDEX | NOT First Time RUN.');
         await this.store.updateFromConfig(blockStorage, this.$config);
@@ -57,7 +57,7 @@ export default defineComponent({
     }
   },
   methods: {
-    checkDev() {
+    checkDevAndDisableContextMenu() {
       if (util.CONTEXT_MENU === 'OFF')
         document.addEventListener('contextmenu', (event) =>
           event.preventDefault()


### PR DESCRIPTION
We were using `shell.open()` on the frontend to open the log folder (via default OS file explorer). 
This was issue#4 from the audit. 

I made a backend function to handle this, and disabled `shell -> open` access for the frontend. This should fix #338 , and also help #339.

Along the way: 
- I fixed the typos and outdated stuff in the `architecture.md` file, this was mentioned in #340 , so we can complete that sub-task in that issue after this PR merges.
- fixed (9999 - 1000 + 1) 
- fixed weirdly named `checkDev()`
- Duplicate code for config creation


