### PR TITLE
restrict osascript for frontend

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
     "trailingComma": "none",
     "tabWidth": 2,
-    "semi": false,
+    "semi": true,
     "attributeSeparator": "none",
+    "singleQuote": true
   }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -85,7 +85,7 @@
           {
             "name": "run-osascript",
             "cmd": "osascript",
-            "args": true
+            "args": ["-e", { "validator": "tell application \"System Events\" to (get the name of every login item|delete login item \\S+|make login item at end with properties \\{path:\\S+, hidden:\\S+, name:\\S+\\})" }]
           }
         ]
       },

--- a/src/components/mainMenu.vue
+++ b/src/components/mainMenu.vue
@@ -50,8 +50,7 @@ export default defineComponent({
   data() {
     return {
       util,
-      launchOnStart: false,
-      disableAutoLaunch: false
+      launchOnStart: false
     };
   },
   mounted() {
@@ -59,13 +58,6 @@ export default defineComponent({
   },
   methods: {
     async toggleClicked() {
-      if (this.disableAutoLaunch) {
-        Notify.create({
-          message: this.$t('menu.autoLaunchNotSupported'),
-          icon: 'info'
-        });
-        return;
-      }
       console.log('toggle Clicked', this.launchOnStart);
       if (this.launchOnStart) {
         Notify.create({
@@ -115,7 +107,11 @@ export default defineComponent({
         cancel: true
       }).onOk(async () => {
         try {
-          await util.resetAndClear({ plotDir, localStorage, config: this.$config });
+          await util.resetAndClear({
+            plotDir,
+            localStorage,
+            config: this.$config
+          });
           await new Promise((resolve) => setTimeout(resolve, 1000));
           await process.relaunch();
         } catch (error) {
@@ -135,12 +131,7 @@ export default defineComponent({
       }
     },
     async initMenu() {
-      if (await this.$autoLauncher.isEnabled()) {
-        this.launchOnStart = true;
-      } else {
-        this.launchOnStart = false;
-        this.disableAutoLaunch = true;
-      }
+      this.launchOnStart = await this.$autoLauncher.isEnabled();
     },
     async installNewUpdate() {
       await event.emit('tauri://update');
@@ -150,5 +141,4 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-
 </style>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -99,7 +99,6 @@
     "reset": "Reset Node!",
     "autoStart": "Start on Boot",
     "export_log": "Show Logs",
-    "autoLaunchNotSupported": "Launch on Boot is not supported on this system.",
     "willAutoLaunch": "Subspace will launch automatically during boot",
     "willNotAutoLaunch": "Subspace will not launch automatically during boot",
     "reset_heading": "Are you sure you want to reset and start from scratch?",

--- a/src/lib/autoLauncher.ts
+++ b/src/lib/autoLauncher.ts
@@ -168,8 +168,8 @@ interface AutoLauncherParams {
   osAutoLauncher: MacOSAutoLauncher | WindowsAutoLauncher | LinuxAutoLauncher;
 }
 
-/** 
- * AutoLauncher class responsible for enabling and disabling auto launch for particular OS 
+/**
+ * AutoLauncher class responsible for enabling and disabling auto launch for particular OS
  */
 class AutoLauncher {
   private osAutoLauncher: MacOSAutoLauncher | WindowsAutoLauncher | LinuxAutoLauncher;


### PR DESCRIPTION
1. we have a new long regex... This will help to prevent commands other than those defined by us to be executed. Stepping towards fixing the frontend privilege issue #339 
2. `disableAutoLaunch` was creating a bug (where user disables the autolaunch, and restarts the application), so I removed that logic completely. I figured out it was not helpful to the user in any of the possible scenarios.
3. prettierrc compliance with eslint